### PR TITLE
new Flag for 'archive' allows to set the languages for subtitles 

### DIFF
--- a/cli/commands/archive/archive.go
+++ b/cli/commands/archive/archive.go
@@ -530,21 +530,12 @@ func archiveDownloadVideos(downloader crunchyroll.Downloader, filename string, v
 	return files, nil
 }
 
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
 func archiveDownloadSubtitles(filename string, subtitles ...*crunchyroll.Subtitle) ([]string, error) {
 	var files []string
 
 	for _, subtitle := range subtitles {
 		if len(archiveSubLanguagesFlag) > 0 {
-			if !stringInSlice(string(subtitle.Locale), archiveSubLanguagesFlag) {
+			if !utils.ElementInSlice(string(subtitle.Locale), archiveSubLanguagesFlag) {
 				continue
 			}
 		}

--- a/cli/commands/archive/archive.go
+++ b/cli/commands/archive/archive.go
@@ -5,12 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/crunchy-labs/crunchy-cli/cli/commands"
-	"github.com/crunchy-labs/crunchy-cli/utils"
-	"github.com/crunchy-labs/crunchyroll-go/v3"
-	crunchyUtils "github.com/crunchy-labs/crunchyroll-go/v3/utils"
-	"github.com/grafov/m3u8"
-	"github.com/spf13/cobra"
 	"io"
 	"math"
 	"os"
@@ -22,10 +16,18 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/crunchy-labs/crunchy-cli/cli/commands"
+	"github.com/crunchy-labs/crunchy-cli/utils"
+	"github.com/crunchy-labs/crunchyroll-go/v3"
+	crunchyUtils "github.com/crunchy-labs/crunchyroll-go/v3/utils"
+	"github.com/grafov/m3u8"
+	"github.com/spf13/cobra"
 )
 
 var (
-	archiveLanguagesFlag []string
+	archiveLanguagesFlag    []string
+	archiveSubLanguagesFlag []string
 
 	archiveDirectoryFlag string
 	archiveOutputFlag    string
@@ -68,6 +70,18 @@ var Cmd = &cobra.Command{
 			}
 		}
 		utils.Log.Debug("Using following audio locales: %s", strings.Join(archiveLanguagesFlag, ", "))
+
+		for _, locale := range archiveSubLanguagesFlag {
+			if !crunchyUtils.ValidateLocale(crunchyroll.LOCALE(locale)) {
+				// if locale is 'all', match all known locales
+				if locale == "all" {
+					archiveSubLanguagesFlag = utils.LocalesAsStrings()
+					break
+				}
+				return fmt.Errorf("%s is not a valid locale for Subtitels. Choose from: %s", locale, strings.Join(utils.LocalesAsStrings(), ", "))
+			}
+		}
+		utils.Log.Debug("Using following subtitels locales: %s", strings.Join(archiveSubLanguagesFlag, ", "))
 
 		var found bool
 		for _, mode := range []string{"auto", "audio", "video"} {
@@ -127,12 +141,20 @@ func init() {
 		[]string{string(utils.SystemLocale(false)), string(crunchyroll.JP)},
 		"Audio locale which should be downloaded. Can be used multiple times")
 
+	Cmd.Flags().StringSliceVarP(&archiveSubLanguagesFlag,
+		"sublang",
+		"s",
+		[]string{},
+		"Subtitles langs which should be downloaded. Can be used multiple times")
+
 	cwd, _ := os.Getwd()
+
 	Cmd.Flags().StringVarP(&archiveDirectoryFlag,
 		"directory",
 		"d",
 		cwd,
 		"The directory to store the files into")
+
 	Cmd.Flags().StringVarP(&archiveOutputFlag,
 		"output",
 		"o",
@@ -147,6 +169,7 @@ func init() {
 			"\t{fps} » Frame Rate of the video\n"+
 			"\t{audio} » Audio locale of the video\n"+
 			"\t{subtitle} » Subtitle locale of the video")
+
 	Cmd.Flags().StringVar(&archiveTempDirFlag,
 		"temp",
 		os.TempDir(),
@@ -507,10 +530,25 @@ func archiveDownloadVideos(downloader crunchyroll.Downloader, filename string, v
 	return files, nil
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func archiveDownloadSubtitles(filename string, subtitles ...*crunchyroll.Subtitle) ([]string, error) {
 	var files []string
 
 	for _, subtitle := range subtitles {
+		if len(archiveSubLanguagesFlag) > 0 {
+			if !stringInSlice(string(subtitle.Locale), archiveSubLanguagesFlag) {
+				continue
+			}
+		}
+
 		f, err := os.CreateTemp("", fmt.Sprintf("%s_%s_subtitle_*.ass", filename, subtitle.Locale))
 		if err != nil {
 			return nil, err

--- a/utils/std.go
+++ b/utils/std.go
@@ -1,0 +1,10 @@
+package utils
+
+func ElementInSlice[T comparable](check T, toCheck []T) bool {
+	for _, item := range toCheck {
+		if check == item {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
I have added a new Flag for the archive command to set the Languages of Subtitels which should be downloaded
If not specified, all subtitles will be loaded

Tested with Command
```
./crunchy archive 'LINK' --merge audio  -v --resolution worst -l ja-JP -l de-DE --sublang de-DE -s  en-US
```

Log:
```
[debug] Executing `archive` command with 1 arg(s)
[debug] Validating arguments
[debug] FFmpeg detected
[debug] Using following audio locales: ja-JP, de-DE
[debug] Using following subtitels locales: de-DE, en-US
[debug] Using audio merge behavior
[debug] Using resolution 'worst'

[debug] Parsing url 1
[debug] Parsed url 1
...
[debug] Merging segments
[debug] Downloaded 'de-DE' video
[debug] Downloaded 'en-US' subtitles
[debug] Downloaded 'de-DE' subtitles
[debug] FFmpeg merge command: ffmpeg .....
[debug] Re-encode to short video length
[debug] Download finished
[debug] Stopped signal catcher
```

Message on 'crunchy-cli archive --help'
```
...
-s, --sublang strings     Subtitles langs which should be downloaded. Can be used multiple times
...
```

MediaInfo
```
Allgemein
Format                                   : Matroska
Format-Version                           : Version 4
Dateigröße                               : 109 MiB
Dauer                                    : 24 min 2s
Gesamte Bitrate                          : 632 kb/s

Video
ID                                       : 1
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Dauer                                    : 24 min 2s
Titel                                    : Japanese
Sprache                                  : Japanisch (JP)

Audio #1
ID                                       : 2
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Dauer                                    : 24 min 2s
Titel                                    : Japanese
Sprache                                  : Japanisch (JP)

Audio #2
ID                                       : 3
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Dauer                                    : 24 min 2s
Titel                                    : German
Sprache                                  : Deutsch (DE)

Text #1
ID                                       : 4
Format                                   : ASS
Dauer                                    : 22 min 39s
Titel                                    : English (US)
Sprache                                  : Englisch (US)

Text #2
ID                                       : 5
Format                                   : ASS
Dauer                                    : 23 min 1s
Titel                                    : German
Sprache                                  : Deutsch (DE)
```
