### PR TITLE
Fix FFMPEG audio encoding

### DIFF
--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -243,6 +243,7 @@ async fn download_ffmpeg(
         .args(["-f", "mpegts", "-i", "pipe:"])
         .args(["-safe", "0"])
         .args(["-c", "copy"])
+        .args(["-bsf:a", "aac_adtstoasc"])
         .arg(target.to_str().unwrap())
         .spawn()?;
 


### PR DESCRIPTION
According to the FFMPEG website this argument (included in the commit) is required when encoding an AAC audio stream from an MPEG-TS file into other formats

https://ffmpeg.org/ffmpeg-bitstream-filters.html#toc-aac_005fadtstoasc

Without this argument the encoded video file will have a longer duration than normal (usually 20-25 seconds more) and will present noticeable audio pops every 3-7 seconds

There might be a better way to implement this as this fix only considers formats related to MP4, so it may be not needed by other formats, however since i do not have much programming experience i'm unable to provide a better alternative, so i at the very least hope this encoding option can be applied to MP4 files 