### PR TITLE
Add optional ffmpeg optimizations

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -223,7 +223,12 @@ pub struct Archive {
     #[arg(value_parser = MergeBehavior::parse)]
     merge: MergeBehavior,
 
-    #[arg(help = format!("Presets for audio converting. Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
+    #[arg(help = format!("Presets for audio converting. \
+    Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
+    #[arg(help = format!("Presets for audio converting. \
+    Generally used to minify the file size with keeping (nearly) the same quality. \
+    It is recommended to only use this if you archive videos with high resolutions since low resolution videos tend to result in a larger file with any of the provided presets. \
+    Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
     #[arg(long)]
     #[arg(value_parser = FFmpegPreset::parse)]
     ffmpeg_preset: Vec<FFmpegPreset>,

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -93,9 +93,9 @@ pub struct Archive {
     #[arg(value_parser = MergeBehavior::parse)]
     merge: MergeBehavior,
 
-    #[arg(help = format!("Presets for video converting. \
+    #[arg(help = format!("Presets for video converting. Can be used multiple times. \
     Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
-    #[arg(help = format!("Presets for video converting. \
+    #[arg(long_help = format!("Presets for video converting. Can be used multiple times. \
     Generally used to minify the file size with keeping (nearly) the same quality. \
     It is recommended to only use this if you archive videos with high resolutions since low resolution videos tend to result in a larger file with any of the provided presets. \
     Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -8,7 +8,7 @@ use crate::utils::parse::{parse_url, UrlFilter};
 use crate::utils::sort::{sort_formats_after_seasons, sort_seasons_after_number};
 use crate::Execute;
 use anyhow::{bail, Result};
-use chrono::{NaiveTime, Timelike};
+use chrono::NaiveTime;
 use crunchyroll_rs::media::{Resolution, StreamSubtitle};
 use crunchyroll_rs::{Locale, Media, MediaCollection, Series};
 use log::{debug, error, info};
@@ -402,7 +402,9 @@ async fn download_video(ctx: &Context, format: &Format, only_audio: bool) -> Res
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .arg("-y")
-        .args(["-f", "mpegts", "-i", "pipe:"])
+        .args(["-f", "mpegts"])
+        .args(["-i", "pipe:"])
+        .args(["-c", "copy"])
         .args(if only_audio { vec!["-vn"] } else { vec![] })
         .arg(path.to_str().unwrap())
         .spawn()?;

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -68,7 +68,12 @@ impl Execute for Download {
     fn pre_check(&self) -> Result<()> {
         if has_ffmpeg() {
             debug!("FFmpeg detected")
-        } else if PathBuf::from(&self.output).extension().unwrap_or_default().to_string_lossy() != "ts" {
+        } else if PathBuf::from(&self.output)
+            .extension()
+            .unwrap_or_default()
+            .to_string_lossy()
+            != "ts"
+        {
             bail!("File extension is not '.ts'. If you want to use a custom file format, please install ffmpeg")
         }
 

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -1,5 +1,5 @@
 use crate::cli::log::tab_info;
-use crate::cli::utils::{download_segments, find_resolution};
+use crate::cli::utils::{download_segments, FFmpegPreset, find_resolution};
 use crate::utils::context::Context;
 use crate::utils::format::{format_string, Format};
 use crate::utils::log::progress;
@@ -12,7 +12,7 @@ use crunchyroll_rs::media::{Resolution, VariantData};
 use crunchyroll_rs::{
     Episode, Locale, Media, MediaCollection, Movie, MovieListing, Season, Series,
 };
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -59,6 +59,16 @@ pub struct Download {
     #[arg(value_parser = crate::utils::clap::clap_parse_resolution)]
     resolution: Resolution,
 
+    #[arg(help = format!("Presets for video converting. \
+    Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
+    #[arg(help = format!("Presets for video converting. \
+    Generally used to minify the file size with keeping (nearly) the same quality. \
+    It is recommended to only use this if you download videos with high resolutions since low resolution videos tend to result in a larger file with any of the provided presets. \
+    Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
+    #[arg(long)]
+    #[arg(value_parser = FFmpegPreset::parse)]
+    ffmpeg_preset: Vec<FFmpegPreset>,
+
     #[arg(help = "Url(s) to Crunchyroll episodes or series")]
     urls: Vec<String>,
 }
@@ -75,6 +85,13 @@ impl Execute for Download {
             != "ts"
         {
             bail!("File extension is not '.ts'. If you want to use a custom file format, please install ffmpeg")
+        } else if !self.ffmpeg_preset.is_empty() {
+            bail!("FFmpeg is required to use (ffmpeg) presets")
+        }
+
+        let _ = FFmpegPreset::ffmpeg_presets(self.ffmpeg_preset.clone())?;
+        if self.ffmpeg_preset.len() == 1 && self.ffmpeg_preset.get(0).unwrap() == &FFmpegPreset::Nvidia {
+            warn!("Skipping 'nvidia' hardware acceleration preset since no other codec preset was specified")
         }
 
         Ok(())
@@ -211,8 +228,8 @@ impl Execute for Download {
                 tab_info!("Resolution: {}", format.stream.resolution);
                 tab_info!("FPS: {:.2}", format.stream.fps);
 
-                if path.extension().unwrap_or_default().to_string_lossy() != "ts" {
-                    download_ffmpeg(&ctx, format.stream, path.as_path()).await?;
+                if path.extension().unwrap_or_default().to_string_lossy() != "ts" || !self.ffmpeg_preset.is_empty() {
+                    download_ffmpeg(&ctx, &self, format.stream, path.as_path()).await?;
                 } else if path.to_str().unwrap() == "-" {
                     let mut stdout = std::io::stdout().lock();
                     download_segments(&ctx, &mut stdout, None, format.stream).await?;
@@ -227,15 +244,18 @@ impl Execute for Download {
     }
 }
 
-async fn download_ffmpeg(ctx: &Context, variant_data: VariantData, target: &Path) -> Result<()> {
+async fn download_ffmpeg(ctx: &Context, download: &Download, variant_data: VariantData, target: &Path) -> Result<()> {
+    let (input_presets, output_presets) =
+        FFmpegPreset::ffmpeg_presets(download.ffmpeg_preset.clone())?;
+
     let ffmpeg = Command::new("ffmpeg")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .arg("-y")
+        .args(input_presets)
         .args(["-f", "mpegts", "-i", "pipe:"])
-        .args(["-safe", "0"])
-        .args(["-c", "copy"])
+        .args(output_presets)
         .arg(target.to_str().unwrap())
         .spawn()?;
 

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -59,9 +59,9 @@ pub struct Download {
     #[arg(value_parser = crate::utils::clap::clap_parse_resolution)]
     resolution: Resolution,
 
-    #[arg(help = format!("Presets for video converting. \
+    #[arg(help = format!("Presets for video converting. Can be used multiple times. \
     Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]
-    #[arg(help = format!("Presets for video converting. \
+    #[arg(long_help = format!("Presets for video converting. Can be used multiple times. \
     Generally used to minify the file size with keeping (nearly) the same quality. \
     It is recommended to only use this if you download videos with high resolutions since low resolution videos tend to result in a larger file with any of the provided presets. \
     Available presets: \n  {}", FFmpegPreset::all().into_iter().map(|p| format!("{}: {}", p.to_string(), p.description())).collect::<Vec<String>>().join("\n  ")))]

--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -1,5 +1,5 @@
 use crate::utils::context::Context;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use crunchyroll_rs::media::{Resolution, VariantData, VariantSegment};
 use isahc::AsyncReadResponseExt;
 use log::{debug, LevelFilter};
@@ -182,4 +182,125 @@ pub async fn download_segments(
     }
 
     Ok(())
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FFmpegPreset {
+    Nvidia,
+
+    Av1,
+    H265,
+    H264,
+}
+
+impl ToString for FFmpegPreset {
+    fn to_string(&self) -> String {
+        match self {
+            &FFmpegPreset::Nvidia => "nvidia",
+            &FFmpegPreset::Av1 => "av1",
+            &FFmpegPreset::H265 => "h265",
+            &FFmpegPreset::H264 => "h264",
+        }
+            .to_string()
+    }
+}
+
+impl FFmpegPreset {
+    pub(crate) fn all() -> Vec<FFmpegPreset> {
+        vec![
+            FFmpegPreset::Nvidia,
+            FFmpegPreset::Av1,
+            FFmpegPreset::H265,
+            FFmpegPreset::H264,
+        ]
+    }
+
+    pub(crate) fn description(self) -> String {
+        match self {
+            FFmpegPreset::Nvidia => "If you're have a nvidia card, use hardware / gpu accelerated video processing if available",
+            FFmpegPreset::Av1 => "Encode the video(s) with the av1 codec. Hardware acceleration is currently not possible with this",
+            FFmpegPreset::H265 => "Encode the video(s) with the h265 codec",
+            FFmpegPreset::H264 => "Encode the video(s) with the h264 codec"
+        }.to_string()
+    }
+
+    pub(crate) fn parse(s: &str) -> Result<FFmpegPreset, String> {
+        Ok(match s.to_lowercase().as_str() {
+            "nvidia" => FFmpegPreset::Nvidia,
+            "av1" => FFmpegPreset::Av1,
+            "h265" | "h.265" | "hevc" => FFmpegPreset::H265,
+            "h264" | "h.264" => FFmpegPreset::H264,
+            _ => return Err(format!("'{}' is not a valid ffmpeg preset", s)),
+        })
+    }
+
+    pub(crate) fn ffmpeg_presets(mut presets: Vec<FFmpegPreset>) -> Result<(Vec<String>, Vec<String>)> {
+        fn preset_check_remove(presets: &mut Vec<FFmpegPreset>, preset: FFmpegPreset) -> bool {
+            if let Some(i) = presets.iter().position(|p| p == &preset) {
+                presets.remove(i);
+                true
+            } else {
+                false
+            }
+        }
+
+        let nvidia = preset_check_remove(&mut presets, FFmpegPreset::Nvidia);
+        if presets.len() > 1 {
+            bail!(
+                "Can only use one video codec, {} found: {}",
+                presets.len(),
+                presets
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )
+        }
+
+        let (mut input, mut output) = (vec![], vec![]);
+        for preset in presets {
+            if nvidia {
+                match preset {
+                    FFmpegPreset::Av1 => bail!("'nvidia' hardware acceleration preset is not available in combination with the 'av1' codec preset"),
+                    FFmpegPreset::H265 => {
+                        input.extend(["-hwaccel", "cuvid", "-c:v", "h264_cuvid"]);
+                        output.extend(["-c:v", "hevc_nvenc"]);
+                    }
+                    FFmpegPreset::H264 => {
+                        input.extend(["-hwaccel", "cuvid", "-c:v", "h264_cuvid"]);
+                        output.extend(["-c:v", "h264_nvenc"]);
+                    }
+                    _ => ()
+                }
+            } else {
+                match preset {
+                    FFmpegPreset::Av1 => {
+                        output.extend(["-c:v", "libaom-av1"]);
+                    }
+                    FFmpegPreset::H265 => {
+                        output.extend(["-c:v", "libx265"]);
+                    }
+                    FFmpegPreset::H264 => {
+                        output.extend(["-c:v", "libx264"]);
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        if input.is_empty() && output.is_empty() {
+            output.extend(["-c", "copy"])
+        } else {
+            if output.is_empty() {
+                output.extend(["-c", "copy"])
+            } else {
+                output.extend(["-c:a", "copy", "-c:s", "copy"])
+            }
+        }
+
+        Ok((
+            input.into_iter().map(|i| i.to_string()).collect(),
+            output.into_iter().map(|o| o.to_string()).collect(),
+        ))
+    }
 }

--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -169,7 +169,7 @@ pub async fn download_segments(
             data_pos += 1;
         }
 
-        if *count.lock().unwrap() >= total_segments {
+        if *count.lock().unwrap() >= total_segments && buf.is_empty() {
             break;
         }
     }

--- a/crunchy-cli-core/src/lib.rs
+++ b/crunchy-cli-core/src/lib.rs
@@ -16,7 +16,9 @@ pub use cli::{archive::Archive, download::Download, login::Login};
 
 #[async_trait::async_trait(?Send)]
 trait Execute {
-    fn pre_check(&self) -> Result<()> { Ok(()) }
+    fn pre_check(&self) -> Result<()> {
+        Ok(())
+    }
     async fn execute(self, ctx: Context) -> Result<()>;
 }
 

--- a/crunchy-cli-core/src/utils/os.rs
+++ b/crunchy-cli-core/src/utils/os.rs
@@ -51,5 +51,7 @@ pub fn free_file(mut path: PathBuf) -> PathBuf {
 
 /// Sanitizes the given path to not contain any invalid file character.
 pub fn sanitize_file(path: PathBuf) -> PathBuf {
-    path.with_file_name(sanitize_filename::sanitize(path.file_name().unwrap().to_string_lossy()))
+    path.with_file_name(sanitize_filename::sanitize(
+        path.file_name().unwrap().to_string_lossy(),
+    ))
 }


### PR DESCRIPTION
This adds the `--ffmpeg-preset` flag to `download` and `archive` which can be used to optimize / influence the downloaded videos via specific defined presets. This is mainly to change video codecs and minify the resulting video file size.

This encodes the video with h265 / hevc via a nvidia gpu, for example:
```shell
$ crunchy ... --ffmpeg-preset nvida --ffmpeg-preset h265 ...
```