### PR TITLE
Fix non existing parent directory

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -647,6 +647,13 @@ fn generate_mkv(
 
     debug!("ffmpeg {}", command_args.join(" "));
 
+    // create parent directory if it does not exist
+    if let Some(parent) = target.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?
+        }
+    }
+
     let ffmpeg = Command::new("ffmpeg")
         .stdout(Stdio::null())
         .stderr(Stdio::piped())

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -3,7 +3,7 @@ use crate::cli::utils::{download_segments, find_resolution, FFmpegPreset};
 use crate::utils::context::Context;
 use crate::utils::format::{format_string, Format};
 use crate::utils::log::progress;
-use crate::utils::os::{free_file, has_ffmpeg, tempfile};
+use crate::utils::os::{free_file, has_ffmpeg, is_special_file, tempfile};
 use crate::utils::parse::{parse_url, UrlFilter};
 use crate::utils::sort::{sort_formats_after_seasons, sort_seasons_after_number};
 use crate::Execute;
@@ -133,6 +133,7 @@ impl Execute for Archive {
             .unwrap_or_default()
             .to_string_lossy()
             != "mkv"
+            && !is_special_file(PathBuf::from(&self.output))
         {
             bail!("File extension is not '.mkv'. Currently only matroska / '.mkv' files are supported")
         }
@@ -251,7 +252,11 @@ impl Execute for Archive {
                 info!(
                     "Downloading {} to '{}'",
                     primary.title,
-                    path.to_str().unwrap()
+                    if is_special_file(&path) {
+                        path.to_str().unwrap()
+                    } else {
+                        path.file_name().unwrap().to_str().unwrap()
+                    }
                 );
                 tab_info!(
                     "Episode: S{:02}E{:02}",

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -240,6 +240,12 @@ impl Execute for Download {
                     let mut stdout = std::io::stdout().lock();
                     download_segments(&ctx, &mut stdout, None, format.stream).await?;
                 } else {
+                    // create parent directory if it does not exist
+                    if let Some(parent) = path.parent() {
+                        if !parent.exists() {
+                            std::fs::create_dir_all(parent)?
+                        }
+                    }
                     let mut file = File::options().create(true).write(true).open(&path)?;
                     download_segments(&ctx, &mut file, None, format.stream).await?
                 }
@@ -258,6 +264,13 @@ async fn download_ffmpeg(
 ) -> Result<()> {
     let (input_presets, output_presets) =
         FFmpegPreset::ffmpeg_presets(download.ffmpeg_preset.clone())?;
+
+    // create parent directory if it does not exist
+    if let Some(parent) = target.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?
+        }
+    }
 
     let mut ffmpeg = Command::new("ffmpeg")
         .stdin(Stdio::piped())

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -3,7 +3,7 @@ use crate::cli::utils::{download_segments, find_resolution, FFmpegPreset};
 use crate::utils::context::Context;
 use crate::utils::format::{format_string, Format};
 use crate::utils::log::progress;
-use crate::utils::os::{free_file, has_ffmpeg};
+use crate::utils::os::{free_file, has_ffmpeg, is_special_file};
 use crate::utils::parse::{parse_url, UrlFilter};
 use crate::utils::sort::{sort_formats_after_seasons, sort_seasons_after_number};
 use crate::Execute;
@@ -219,7 +219,11 @@ impl Execute for Download {
                 info!(
                     "Downloading {} to '{}'",
                     format.title,
-                    path.file_name().unwrap().to_str().unwrap()
+                    if is_special_file(&path) {
+                        path.to_str().unwrap()
+                    } else {
+                        path.file_name().unwrap().to_str().unwrap()
+                    }
                 );
                 tab_info!("Episode: S{:02}E{:02}", format.season_number, format.number);
                 tab_info!("Audio: {}", format.audio);
@@ -232,9 +236,9 @@ impl Execute for Download {
                 tab_info!("Resolution: {}", format.stream.resolution);
                 tab_info!("FPS: {:.2}", format.stream.fps);
 
-                if path.extension().unwrap_or_default().to_string_lossy() != "ts"
-                    || !self.ffmpeg_preset.is_empty()
-                {
+                let extension = path.extension().unwrap_or_default().to_string_lossy();
+
+                if (!extension.is_empty() && extension != "ts") || !self.ffmpeg_preset.is_empty() {
                     download_ffmpeg(&ctx, &self, format.stream, path.as_path()).await?;
                 } else if path.to_str().unwrap() == "-" {
                     let mut stdout = std::io::stdout().lock();
@@ -279,6 +283,19 @@ async fn download_ffmpeg(
         .arg("-y")
         .args(input_presets)
         .args(["-f", "mpegts", "-i", "pipe:"])
+        .args(
+            if target
+                .extension()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .is_empty()
+            {
+                vec!["-f", "mpegts"]
+            } else {
+                vec![]
+            }
+            .as_slice(),
+        )
         .args(output_presets)
         .arg(target.to_str().unwrap())
         .spawn()?;

--- a/crunchy-cli-core/src/utils/os.rs
+++ b/crunchy-cli-core/src/utils/os.rs
@@ -37,6 +37,12 @@ pub fn tempfile<S: AsRef<str>>(suffix: S) -> io::Result<NamedTempFile> {
 
 /// Check if the given path exists and rename it until the new (renamed) file does not exist.
 pub fn free_file(mut path: PathBuf) -> PathBuf {
+    // if path is not a file and not a dir it's probably a pipe on linux which reguarly is intended
+    // and thus does not need to be renamed. what it is on windows ¯\_(ツ)_/¯
+    if !path.is_file() && !path.is_dir() {
+        return path;
+    }
+
     let mut i = 0;
     while path.exists() {
         i += 1;


### PR DESCRIPTION
Fix for #91. Any command failed if the parent directory of the via `-o` specified file does not exist, this PR fixes this and creates the directories.