### PR TITLE
Add debug segment percentage

### DIFF
--- a/crunchy-cli-core/src/cli/log.rs
+++ b/crunchy-cli-core/src/cli/log.rs
@@ -75,8 +75,9 @@ impl CliLogger {
             // replace the 'progress' prefix if this function is invoked via 'progress!'
             record
                 .target()
-                .replacen("progress", "crunchy_cli", 1)
-                .replacen("progress_end", "crunchy_cli", 1),
+                .replacen("crunchy_cli_core", "crunchy_cli", 1)
+                .replacen("progress_end", "crunchy_cli", 1)
+                .replacen("progress", "crunchy_cli", 1),
             format!("{:?}", thread::current().id())
                 .replace("ThreadId(", "")
                 .replace(')', ""),

--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -80,14 +80,18 @@ pub async fn download_segments(
                 let mut buf = response.bytes().await?.to_vec();
 
                 buf = VariantSegment::decrypt(buf.borrow_mut(), segment.key)?.to_vec();
+
+                let mut c = thread_count.lock().unwrap();
                 debug!(
-                    "Downloaded and decrypted segment {} ({})",
+                    "Downloaded and decrypted segment [{}/{} {:.2}%] {}",
                     num + (i * cpus),
+                    total_segments,
+                    ((*c + 1) as f64 / total_segments as f64) * 100f64,
                     segment.url
                 );
                 thread_sender.send((num + (i * cpus), buf))?;
 
-                *thread_count.lock().unwrap() += 1;
+                *c += 1;
             }
 
             Ok(())

--- a/crunchy-cli-core/src/utils/os.rs
+++ b/crunchy-cli-core/src/utils/os.rs
@@ -41,8 +41,8 @@ pub fn free_file(mut path: PathBuf) -> PathBuf {
     while path.exists() {
         i += 1;
 
-        let ext = path.extension().unwrap().to_string_lossy();
-        let mut filename = path.file_stem().unwrap().to_str().unwrap();
+        let ext = path.extension().unwrap_or_default().to_string_lossy();
+        let mut filename = path.file_stem().unwrap_or_default().to_str().unwrap();
 
         if filename.ends_with(&format!(" ({})", i - 1)) {
             filename = filename.strip_suffix(&format!(" ({})", i - 1)).unwrap();


### PR DESCRIPTION
Slightly modifies the debug output. Changed layout of debug segment download output and every `crunchy_cli_core` output name was renamed to `crunchy_cli`.