### PR TITLE
Archive subtitles of all versions of an episode

### DIFF
--- a/crunchy-cli-core/src/utils/mod.rs
+++ b/crunchy-cli-core/src/utils/mod.rs
@@ -6,3 +6,4 @@ pub mod log;
 pub mod os;
 pub mod parse;
 pub mod sort;
+pub mod subtitle;

--- a/crunchy-cli-core/src/utils/subtitle.rs
+++ b/crunchy-cli-core/src/utils/subtitle.rs
@@ -1,0 +1,11 @@
+use crunchyroll_rs::media::StreamSubtitle;
+use crunchyroll_rs::Locale;
+
+#[derive(Clone)]
+pub struct Subtitle {
+    pub stream_subtitle: StreamSubtitle,
+    pub audio_locale: Locale,
+    pub episode_id: String,
+    pub forced: bool,
+    pub primary: bool,
+}


### PR DESCRIPTION
Until now, only subtitles from the season that occurs first in the list of seasons were considered for downloading. This fix downloads the subtitles for all the selected locales. "Duplicates" are probably fine here, as the subtitles contained in non-Japanese streams are forced ones and differ from the ones supplied in the version with Japanese audio.

In theory, it would even be possible to flag those forced ones within an mkv file. But for now, I think this is fine (?). Let me know otherwise.