### PR TITLE
Interactive choosing on duplicated season numbers

### DIFF
--- a/crunchy-cli-core/src/utils/sort.rs
+++ b/crunchy-cli-core/src/utils/sort.rs
@@ -30,8 +30,11 @@ pub fn sort_formats_after_seasons(formats: Vec<Format>) -> Vec<Vec<Format>> {
     let mut as_map = BTreeMap::new();
 
     for format in formats {
-        as_map.entry(format.season_number).or_insert_with(Vec::new);
-        as_map.get_mut(&format.season_number).unwrap().push(format);
+        // the season title is used as key instead of season number to distinguish duplicated season
+        // numbers which are actually two different seasons; season id is not used as this somehow
+        // messes up ordering when duplicated seasons exist
+        as_map.entry(format.season_title.clone()).or_insert_with(Vec::new);
+        as_map.get_mut(&format.season_title).unwrap().push(format);
     }
 
     let mut sorted = as_map
@@ -41,7 +44,7 @@ pub fn sort_formats_after_seasons(formats: Vec<Format>) -> Vec<Vec<Format>> {
             values
         })
         .collect::<Vec<Vec<Format>>>();
-    sorted.sort_by(|a, b| a[0].series_id.cmp(&b[0].series_id));
+    sorted.sort_by(|a, b| a[0].season_number.cmp(&b[0].season_number));
 
     sorted
 }


### PR DESCRIPTION
Crunchyroll sometimes marks different seasons with the same season number (eg. Sword Art Online, Demon Slayer). Until now it was impossible to download a specific season if it has a duplicates; always all (duplicated) seasons with the assigned season number were downloaded.
To solve this, a interactive prompt is now shown, if a series has seasons with duplicated season number. The also added `-y`/`--yes` flag can be used to suppress the prompt and download everything without further interactive input.

![image](https://user-images.githubusercontent.com/63594396/211207709-8e9535ad-291e-4002-a81d-9e515eb05b7f.png)
