### PR TITLE
Relative episode number format option

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -208,7 +208,7 @@ impl Execute for Archive {
                             format.stream.resolution,
                             format.stream.fps,
                             format.season_number,
-                            format.number,
+                            format.episode_number,
                         )
                     }
                 }
@@ -234,7 +234,7 @@ impl Execute for Archive {
                             format.stream.resolution,
                             format.stream.fps,
                             format.season_number,
-                            format.number
+                            format.episode_number
                         )
                     }
                 }
@@ -266,7 +266,7 @@ impl Execute for Archive {
                 tab_info!(
                     "Episode: S{:02}E{:02}",
                     primary.season_number,
-                    primary.number
+                    primary.episode_number
                 );
                 tab_info!(
                     "Audio: {} (primary), {}",
@@ -318,7 +318,7 @@ impl Execute for Archive {
 
                     // Remove subtitles of deleted video
                     if only_audio {
-                        subtitles.retain(|s| s.episode_id != additional.id);
+                        subtitles.retain(|s| s.episode_id != additional.episode_id);
                     }
                 }
 

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -67,10 +67,9 @@ pub struct Archive {
       {season_name}             → Name of the season\n  \
       {audio}                   → Audio language of the video\n  \
       {resolution}              → Resolution of the video\n  \
-      {padded_season_number}    → Number of the season padded to double digits\n  \
       {season_number}           → Number of the season\n  \
-      {padded_episode_number}   → Number of the episode padded to double digits\n  \
       {episode_number}          → Number of the episode\n  \
+      {relative_episode_number} → Number of the episode relative to its season\
       {series_id}               → ID of the series\n  \
       {season_id}               → ID of the season\n  \
       {episode_id}              → ID of the episode")]

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -45,10 +45,9 @@ pub struct Download {
       {season_name}             → Name of the season\n  \
       {audio}                   → Audio language of the video\n  \
       {resolution}              → Resolution of the video\n  \
-      {padded_season_number}    → Number of the season padded to double digits\n  \
       {season_number}           → Number of the season\n  \
-      {padded_episode_number}   → Number of the episode padded to double digits\n  \
       {episode_number}          → Number of the episode\n  \
+      {relative_episode_number} → Number of the episode relative to its season\
       {series_id}               → ID of the series\n  \
       {season_id}               → ID of the season\n  \
       {episode_id}              → ID of the episode")]

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -182,7 +182,7 @@ impl Execute for Download {
                             format.stream.resolution,
                             format.stream.fps,
                             format.season_number,
-                            format.number,
+                            format.episode_number,
                         )
                     }
                 }
@@ -202,7 +202,7 @@ impl Execute for Download {
                             format.stream.resolution,
                             format.stream.fps,
                             format.season_number,
-                            format.number
+                            format.episode_number
                         )
                     }
                 }
@@ -229,7 +229,11 @@ impl Execute for Download {
                         path.file_name().unwrap().to_str().unwrap()
                     }
                 );
-                tab_info!("Episode: S{:02}E{:02}", format.season_number, format.number);
+                tab_info!(
+                    "Episode: S{:02}E{:02}",
+                    format.season_number,
+                    format.episode_number
+                );
                 tab_info!("Audio: {}", format.audio);
                 tab_info!(
                     "Subtitles: {}",

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -4,7 +4,7 @@ use crate::cli::utils::{
     interactive_season_choosing, FFmpegPreset,
 };
 use crate::utils::context::Context;
-use crate::utils::format::{format_path, Format};
+use crate::utils::format::Format;
 use crate::utils::log::progress;
 use crate::utils::os::{free_file, has_ffmpeg, is_special_file};
 use crate::utils::parse::{parse_url, UrlFilter};
@@ -16,6 +16,7 @@ use crunchyroll_rs::{
     Episode, Locale, Media, MediaCollection, Movie, MovieListing, Season, Series,
 };
 use log::{debug, error, info, warn};
+use std::borrow::Cow;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -148,7 +149,7 @@ impl Execute for Download {
                         episode.metadata.season_title,
                         episode.metadata.series_title
                     );
-                    format_from_episode(&self, episode, &url_filter, false)
+                    format_from_episode(&self, &episode, &url_filter, None, false)
                         .await?
                         .map(|fmt| vec![fmt])
                 }
@@ -209,16 +210,17 @@ impl Execute for Download {
             }
 
             for format in formats {
-                let path = free_file(format_path(
-                    if self.output.is_empty() {
-                        "{title}.mkv"
-                    } else {
-                        &self.output
-                    }
-                    .into(),
-                    &format,
-                    true,
-                ));
+                let path = free_file(
+                    format.format_path(
+                        if self.output.is_empty() {
+                            "{title}.mkv"
+                        } else {
+                            &self.output
+                        }
+                        .into(),
+                        true,
+                    ),
+                );
 
                 info!(
                     "Downloading {} to '{}'",
@@ -392,8 +394,11 @@ async fn formats_from_season(
 
     let mut formats = vec![];
 
-    for episode in season.episodes().await? {
-        if let Some(fmt) = format_from_episode(download, episode, url_filter, true).await? {
+    let episodes = season.episodes().await?;
+    for episode in episodes.iter() {
+        if let Some(fmt) =
+            format_from_episode(download, &episode, url_filter, Some(&episodes), true).await?
+        {
             formats.push(fmt)
         }
     }
@@ -403,8 +408,9 @@ async fn formats_from_season(
 
 async fn format_from_episode(
     download: &Download,
-    episode: Media<Episode>,
+    episode: &Media<Episode>,
     url_filter: &UrlFilter,
+    season_episodes: Option<&Vec<Media<Episode>>>,
     filter_audio: bool,
 ) -> Result<Option<Format>> {
     if filter_audio && episode.metadata.audio_locale != download.audio {
@@ -457,7 +463,21 @@ async fn format_from_episode(
         )
     };
 
-    Ok(Some(Format::new_from_episode(episode, stream)))
+    let season_eps = if Format::has_relative_episodes_fmt(&download.output) {
+        if let Some(eps) = season_episodes {
+            Cow::from(eps)
+        } else {
+            Cow::from(episode.season().await?.episodes().await?)
+        }
+    } else {
+        Cow::from(vec![])
+    };
+
+    Ok(Some(Format::new_from_episode(
+        episode,
+        &season_eps.to_vec(),
+        stream,
+    )))
 }
 
 async fn format_from_movie_listing(
@@ -515,7 +535,7 @@ async fn format_from_movie(
         }
     };
 
-    Ok(Some(Format::new_from_movie(movie, stream)))
+    Ok(Some(Format::new_from_movie(&movie, stream)))
 }
 
 fn some_vec_or_none<T>(v: Vec<T>) -> Option<Vec<T>> {

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -1,5 +1,6 @@
 use crunchyroll_rs::media::VariantData;
 use crunchyroll_rs::{Episode, Locale, Media, Movie};
+use log::warn;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -22,35 +23,56 @@ pub struct Format {
 
     pub episode_id: String,
     pub episode_number: f32,
+    pub relative_episode_number: f32,
 }
 
 impl Format {
-    pub fn new_from_episode(episode: Media<Episode>, stream: VariantData) -> Self {
+    pub fn new_from_episode(
+        episode: &Media<Episode>,
+        season_episodes: &Vec<Media<Episode>>,
+        stream: VariantData,
+    ) -> Self {
         Self {
-            title: episode.title,
-            description: episode.description,
+            title: episode.title.clone(),
+            description: episode.description.clone(),
 
-            audio: episode.metadata.audio_locale,
+            audio: episode.metadata.audio_locale.clone(),
 
             duration: episode.metadata.duration.to_std().unwrap(),
             stream,
 
-            series_id: episode.metadata.series_id,
-            series_name: episode.metadata.series_title,
+            series_id: episode.metadata.series_id.clone(),
+            series_name: episode.metadata.series_title.clone(),
 
-            season_id: episode.metadata.season_id,
-            season_title: episode.metadata.season_title,
-            season_number: episode.metadata.season_number,
+            season_id: episode.metadata.season_id.clone(),
+            season_title: episode.metadata.season_title.clone(),
+            season_number: episode.metadata.season_number.clone(),
 
-            episode_id: episode.id,
-            episode_number: episode.metadata.episode.parse().unwrap_or(episode.metadata.sequence_number),
+            episode_id: episode.id.clone(),
+            episode_number: episode
+                .metadata
+                .episode
+                .parse()
+                .unwrap_or(episode.metadata.sequence_number),
+            relative_episode_number: season_episodes
+                .iter()
+                .enumerate()
+                .find_map(|(i, e)| if e == episode { Some((i + 1) as f32) } else { None })
+                .unwrap_or_else(|| {
+                    warn!("Cannot find relative episode number for episode {} ({}) of season {} ({}) of {}, using normal episode number", episode.metadata.episode_number, episode.title, episode.metadata.season_number, episode.metadata.season_title, episode.metadata.series_title);
+                    episode
+                        .metadata
+                        .episode
+                        .parse()
+                        .unwrap_or(episode.metadata.sequence_number)
+                }),
         }
     }
 
-    pub fn new_from_movie(movie: Media<Movie>, stream: VariantData) -> Self {
+    pub fn new_from_movie(movie: &Media<Movie>, stream: VariantData) -> Self {
         Self {
-            title: movie.title,
-            description: movie.description,
+            title: movie.title.clone(),
+            description: movie.description.clone(),
 
             audio: Locale::ja_JP,
 
@@ -60,53 +82,65 @@ impl Format {
             series_id: movie.metadata.movie_listing_id.clone(),
             series_name: movie.metadata.movie_listing_title.clone(),
 
-            season_id: movie.metadata.movie_listing_id,
-            season_title: movie.metadata.movie_listing_title,
+            season_id: movie.metadata.movie_listing_id.clone(),
+            season_title: movie.metadata.movie_listing_title.clone(),
             season_number: 1,
 
-            episode_id: movie.id,
+            episode_id: movie.id.clone(),
             episode_number: 1.0,
+            relative_episode_number: 1.0,
         }
     }
-}
 
-/// Formats the given string if it has specific pattern in it. It's possible to sanitize it which
-/// removes characters which can cause failures if the output string is used as a file name.
-pub fn format_path(path: PathBuf, format: &Format, sanitize: bool) -> PathBuf {
-    let sanitize_func = if sanitize {
-        |s: &str| sanitize_filename::sanitize(s)
-    } else {
-        // converting this to a string is actually unnecessary
-        |s: &str| s.to_string()
-    };
+    /// Formats the given string if it has specific pattern in it. It's possible to sanitize it which
+    /// removes characters which can cause failures if the output string is used as a file name.
+    pub fn format_path(&self, path: PathBuf, sanitize: bool) -> PathBuf {
+        let sanitize_func = if sanitize {
+            |s: &str| sanitize_filename::sanitize(s)
+        } else {
+            // converting this to a string is actually unnecessary
+            |s: &str| s.to_string()
+        };
 
-    let as_string = path.to_string_lossy().to_string();
+        let as_string = path.to_string_lossy().to_string();
 
-    PathBuf::from(
-        as_string
-            .replace("{title}", &sanitize_func(&format.title))
-            .replace("{audio}", &sanitize_func(&format.audio.to_string()))
-            .replace(
-                "{resolution}",
-                &sanitize_func(&format.stream.resolution.to_string()),
-            )
-            .replace("{series_id}", &sanitize_func(&format.series_id))
-            .replace("{series_name}", &sanitize_func(&format.series_name))
-            .replace("{season_id}", &sanitize_func(&format.season_id))
-            .replace("{season_name}", &sanitize_func(&format.season_title))
-            .replace(
-                "{season_number}",
-                &sanitize_func(&format.season_number.to_string()),
-            )
-            .replace(
-                "{padded_season_number}",
-                &sanitize_func(&format!("{:0>2}", format.season_number.to_string())),
-            )
-            .replace("{episode_id}", &sanitize_func(&format.episode_id))
-            .replace("{episode_number}", &sanitize_func(&format.episode_number.to_string()))
-            .replace(
-                "{padded_episode_number}",
-                &sanitize_func(&format!("{:0>2}", format.episode_number.to_string())),
-            ),
-    )
+        PathBuf::from(
+            as_string
+                .replace("{title}", &sanitize_func(&self.title))
+                .replace("{audio}", &sanitize_func(&self.audio.to_string()))
+                .replace(
+                    "{resolution}",
+                    &sanitize_func(&self.stream.resolution.to_string()),
+                )
+                .replace("{series_id}", &sanitize_func(&self.series_id))
+                .replace("{series_name}", &sanitize_func(&self.series_name))
+                .replace("{season_id}", &sanitize_func(&self.season_id))
+                .replace("{season_name}", &sanitize_func(&self.season_title))
+                .replace(
+                    "{season_number}",
+                    &sanitize_func(&self.season_number.to_string()),
+                )
+                .replace(
+                    "{padded_season_number}",
+                    &sanitize_func(&format!("{:0>2}", self.season_number.to_string())),
+                )
+                .replace("{episode_id}", &sanitize_func(&self.episode_id))
+                .replace(
+                    "{episode_number}",
+                    &sanitize_func(&self.episode_number.to_string()),
+                )
+                .replace(
+                    "{padded_episode_number}",
+                    &sanitize_func(&format!("{:0>2}", self.episode_number.to_string())),
+                )
+                .replace(
+                    "{relative_episode_number}",
+                    &sanitize_func(&format!("{:0>2}", self.relative_episode_number.to_string())),
+                ),
+        )
+    }
+
+    pub fn has_relative_episodes_fmt<S: AsRef<str>>(s: S) -> bool {
+        return s.as_ref().contains("{relative_episode_number}");
+    }
 }

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -5,10 +5,9 @@ use std::time::Duration;
 
 #[derive(Clone)]
 pub struct Format {
-    pub id: String,
     pub title: String,
     pub description: String,
-    pub number: u32,
+
     pub audio: Locale,
 
     pub duration: Duration,
@@ -20,15 +19,17 @@ pub struct Format {
     pub season_id: String,
     pub season_title: String,
     pub season_number: u32,
+
+    pub episode_id: String,
+    pub episode_number: f32,
 }
 
 impl Format {
     pub fn new_from_episode(episode: Media<Episode>, stream: VariantData) -> Self {
         Self {
-            id: episode.id,
             title: episode.title,
             description: episode.description,
-            number: episode.metadata.episode_number,
+
             audio: episode.metadata.audio_locale,
 
             duration: episode.metadata.duration.to_std().unwrap(),
@@ -40,15 +41,17 @@ impl Format {
             season_id: episode.metadata.season_id,
             season_title: episode.metadata.season_title,
             season_number: episode.metadata.season_number,
+
+            episode_id: episode.id,
+            episode_number: episode.metadata.episode.parse().unwrap_or(episode.metadata.sequence_number),
         }
     }
 
     pub fn new_from_movie(movie: Media<Movie>, stream: VariantData) -> Self {
         Self {
-            id: movie.id,
             title: movie.title,
             description: movie.description,
-            number: 1,
+
             audio: Locale::ja_JP,
 
             duration: movie.metadata.duration.to_std().unwrap(),
@@ -60,6 +63,9 @@ impl Format {
             season_id: movie.metadata.movie_listing_id,
             season_title: movie.metadata.movie_listing_title,
             season_number: 1,
+
+            episode_id: movie.id,
+            episode_number: 1.0,
         }
     }
 }
@@ -79,31 +85,28 @@ pub fn format_path(path: PathBuf, format: &Format, sanitize: bool) -> PathBuf {
     PathBuf::from(
         as_string
             .replace("{title}", &sanitize_func(&format.title))
-            .replace("{series_name}", &sanitize_func(&format.series_name))
-            .replace("{season_name}", &sanitize_func(&format.season_title))
             .replace("{audio}", &sanitize_func(&format.audio.to_string()))
             .replace(
                 "{resolution}",
                 &sanitize_func(&format.stream.resolution.to_string()),
             )
-            .replace(
-                "{padded_season_number}",
-                &sanitize_func(&format!("{:0>2}", format.season_number.to_string())),
-            )
+            .replace("{series_id}", &sanitize_func(&format.series_id))
+            .replace("{series_name}", &sanitize_func(&format.series_name))
+            .replace("{season_id}", &sanitize_func(&format.season_id))
+            .replace("{season_name}", &sanitize_func(&format.season_title))
             .replace(
                 "{season_number}",
                 &sanitize_func(&format.season_number.to_string()),
             )
             .replace(
-                "{padded_episode_number}",
-                &sanitize_func(&format!("{:0>2}", format.number.to_string())),
+                "{padded_season_number}",
+                &sanitize_func(&format!("{:0>2}", format.season_number.to_string())),
             )
+            .replace("{episode_id}", &sanitize_func(&format.episode_id))
+            .replace("{episode_number}", &sanitize_func(&format.episode_number.to_string()))
             .replace(
-                "{episode_number}",
-                &sanitize_func(&format.number.to_string()),
-            )
-            .replace("{series_id}", &sanitize_func(&format.series_id))
-            .replace("{season_id}", &sanitize_func(&format.season_id))
-            .replace("{episode_id}", &sanitize_func(&format.id)),
+                "{padded_episode_number}",
+                &sanitize_func(&format!("{:0>2}", format.episode_number.to_string())),
+            ),
     )
 }

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -118,19 +118,11 @@ impl Format {
                 .replace("{season_name}", &sanitize_func(&self.season_title))
                 .replace(
                     "{season_number}",
-                    &sanitize_func(&self.season_number.to_string()),
-                )
-                .replace(
-                    "{padded_season_number}",
                     &sanitize_func(&format!("{:0>2}", self.season_number.to_string())),
                 )
                 .replace("{episode_id}", &sanitize_func(&self.episode_id))
                 .replace(
                     "{episode_number}",
-                    &sanitize_func(&self.episode_number.to_string()),
-                )
-                .replace(
-                    "{padded_episode_number}",
                     &sanitize_func(&format!("{:0>2}", self.episode_number.to_string())),
                 )
                 .replace(

--- a/crunchy-cli-core/src/utils/sort.rs
+++ b/crunchy-cli-core/src/utils/sort.rs
@@ -42,7 +42,7 @@ pub fn sort_formats_after_seasons(formats: Vec<Format>) -> Vec<Vec<Format>> {
     let mut sorted = as_map
         .into_iter()
         .map(|(_, mut values)| {
-            values.sort_by(|a, b| a.number.cmp(&b.number));
+            values.sort_by(|a, b| a.episode_number.total_cmp(&b.episode_number));
             values
         })
         .collect::<Vec<Vec<Format>>>();


### PR DESCRIPTION
Adds the `{relative_episode_number}` flag for `-o`/`--output` which represents the episode number relative to its season (#64).
It was also considered to add a option to format episodes relative to the series, but this may lead to overfetching in some cases.