### PR TITLE
Manually add subtitles to download videos 

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -9,16 +9,14 @@ use crate::utils::log::progress;
 use crate::utils::os::{free_file, has_ffmpeg, is_special_file, tempfile};
 use crate::utils::parse::{parse_url, UrlFilter};
 use crate::utils::sort::{sort_formats_after_seasons, sort_seasons_after_number};
-use crate::utils::subtitle::Subtitle;
+use crate::utils::subtitle::{download_subtitle, Subtitle};
+use crate::utils::video::get_video_length;
 use crate::Execute;
 use anyhow::{bail, Result};
-use chrono::NaiveTime;
-use crunchyroll_rs::media::{Resolution, StreamSubtitle};
+use crunchyroll_rs::media::Resolution;
 use crunchyroll_rs::{Locale, Media, MediaCollection, Series};
 use log::{debug, error, info, warn};
-use regex::Regex;
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tempfile::TempPath;
@@ -113,14 +111,6 @@ pub struct Archive {
     )]
     #[arg(long)]
     default_subtitle: Option<Locale>,
-    #[arg(help = "Disable subtitle optimizations")]
-    #[arg(
-        long_help = "By default, Crunchyroll delivers subtitles in a format which may cause issues in some video players. \
-    These issues are fixed internally by setting a flag which is not part of the official specification of the subtitle format. \
-    If you do not want this fixes or they cause more trouble than they solve (for you), it can be disabled with this flag"
-    )]
-    #[arg(long)]
-    no_subtitle_optimizations: bool,
 
     #[arg(help = "Ignore interactive input")]
     #[arg(short, long, default_value_t = false)]
@@ -326,12 +316,8 @@ impl Execute for Archive {
                 let primary_video_length = get_video_length(primary_video.to_path_buf()).unwrap();
                 for subtitle in subtitles {
                     subtitle_paths.push((
-                        download_subtitle(
-                            &self,
-                            subtitle.stream_subtitle.clone(),
-                            primary_video_length,
-                        )
-                        .await?,
+                        download_subtitle(subtitle.stream_subtitle.clone(), primary_video_length)
+                            .await?,
                         subtitle,
                     ))
                 }
@@ -436,7 +422,7 @@ async fn formats_from_series(
                 };
                 Some(subtitle)
             }));
-            formats.push(Format::new_from_episode(episode, &episodes, stream));
+            formats.push(Format::new_from_episode(episode, &episodes, stream, vec![]));
         }
 
         primary_season = false;
@@ -474,111 +460,6 @@ async fn download_video(ctx: &Context, format: &Format, only_audio: bool) -> Res
     .await?;
 
     Ok(path)
-}
-
-async fn download_subtitle(
-    archive: &Archive,
-    subtitle: StreamSubtitle,
-    max_length: NaiveTime,
-) -> Result<TempPath> {
-    let tempfile = tempfile(".ass")?;
-    let (mut file, path) = tempfile.into_parts();
-
-    let mut buf = vec![];
-    subtitle.write_to(&mut buf).await?;
-    if !archive.no_subtitle_optimizations {
-        buf = fix_subtitle_look_and_feel(buf)
-    }
-    buf = fix_subtitle_length(buf, max_length);
-
-    file.write_all(buf.as_slice())?;
-
-    Ok(path)
-}
-
-/// Add `ScaledBorderAndShadows: yes` to subtitles; without it they look very messy on some video
-/// players. See [crunchy-labs/crunchy-cli#66](https://github.com/crunchy-labs/crunchy-cli/issues/66)
-/// for more information.
-fn fix_subtitle_look_and_feel(raw: Vec<u8>) -> Vec<u8> {
-    let mut script_info = false;
-    let mut new = String::new();
-
-    for line in String::from_utf8_lossy(raw.as_slice()).split('\n') {
-        if line.trim().starts_with('[') && script_info {
-            new.push_str("ScaledBorderAndShadow: yes\n");
-            script_info = false
-        } else if line.trim() == "[Script Info]" {
-            script_info = true
-        }
-        new.push_str(line);
-        new.push('\n')
-    }
-
-    new.into_bytes()
-}
-
-/// Fix the length of subtitles to a specified maximum amount. This is required because sometimes
-/// subtitles have an unnecessary entry long after the actual video ends with artificially extends
-/// the video length on some video players. To prevent this, the video length must be hard set. See
-/// [crunchy-labs/crunchy-cli#32](https://github.com/crunchy-labs/crunchy-cli/issues/32) for more
-/// information.
-fn fix_subtitle_length(raw: Vec<u8>, max_length: NaiveTime) -> Vec<u8> {
-    let re =
-        Regex::new(r#"^Dialogue:\s\d+,(?P<start>\d+:\d+:\d+\.\d+),(?P<end>\d+:\d+:\d+\.\d+),"#)
-            .unwrap();
-
-    // chrono panics if we try to format NaiveTime with `%2f` and the nano seconds has more than 2
-    // digits so them have to be reduced manually to avoid the panic
-    fn format_naive_time(native_time: NaiveTime) -> String {
-        let formatted_time = native_time.format("%f").to_string();
-        format!(
-            "{}.{}",
-            native_time.format("%T"),
-            if formatted_time.len() <= 2 {
-                native_time.format("%2f").to_string()
-            } else {
-                formatted_time.split_at(2).0.parse().unwrap()
-            }
-        )
-    }
-
-    let length_as_string = format_naive_time(max_length);
-    let mut new = String::new();
-
-    for line in String::from_utf8_lossy(raw.as_slice()).split('\n') {
-        if let Some(capture) = re.captures(line) {
-            let start = capture.name("start").map_or(NaiveTime::default(), |s| {
-                NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S.%f").unwrap()
-            });
-            let end = capture.name("end").map_or(NaiveTime::default(), |s| {
-                NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S.%f").unwrap()
-            });
-
-            if start > max_length {
-                continue;
-            } else if end > max_length {
-                new.push_str(
-                    re.replace(
-                        line,
-                        format!(
-                            "Dialogue: {},{},",
-                            format_naive_time(start),
-                            &length_as_string
-                        ),
-                    )
-                    .to_string()
-                    .as_str(),
-                )
-            } else {
-                new.push_str(line)
-            }
-        } else {
-            new.push_str(line)
-        }
-        new.push('\n')
-    }
-
-    new.into_bytes()
 }
 
 fn generate_mkv(
@@ -720,24 +601,4 @@ fn generate_mkv(
     }
 
     Ok(())
-}
-
-/// Get the length of a video. This is required because sometimes subtitles have an unnecessary entry
-/// long after the actual video ends with artificially extends the video length on some video players.
-/// To prevent this, the video length must be hard set. See
-/// [crunchy-labs/crunchy-cli#32](https://github.com/crunchy-labs/crunchy-cli/issues/32) for more
-/// information.
-fn get_video_length(path: PathBuf) -> Result<NaiveTime> {
-    let video_length = Regex::new(r"Duration:\s(?P<time>\d+:\d+:\d+\.\d+),")?;
-
-    let ffmpeg = Command::new("ffmpeg")
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .arg("-y")
-        .args(["-i", path.to_str().unwrap()])
-        .output()?;
-    let ffmpeg_output = String::from_utf8(ffmpeg.stderr)?;
-    let caps = video_length.captures(ffmpeg_output.as_str()).unwrap();
-
-    Ok(NaiveTime::parse_from_str(caps.name("time").unwrap().as_str(), "%H:%M:%S%.f").unwrap())
 }

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -350,11 +350,11 @@ async fn download_ffmpeg(
         .arg(target.to_str().unwrap())
         .spawn()?;
 
-    let _progress_handler = progress!("Generating output file");
+    let progress_handler = progress!("Generating output file");
     if !ffmpeg.wait()?.success() {
         bail!("{}", std::io::read_to_string(ffmpeg.stderr.unwrap())?)
     }
-    info!("Output file generated");
+    progress_handler.stop("Output file generated");
 
     if let Some(mut stdout_file) = stdout_tempfile {
         let mut stdout = std::io::stdout();

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -340,6 +340,7 @@ async fn download_ffmpeg(
     };
 
     let mut ffmpeg = Command::new("ffmpeg")
+        .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .arg("-y")
         .args(input_presets)
@@ -350,7 +351,9 @@ async fn download_ffmpeg(
         .spawn()?;
 
     let _progress_handler = progress!("Generating output file");
-    ffmpeg.wait()?;
+    if !ffmpeg.wait()?.success() {
+        bail!("{}", std::io::read_to_string(ffmpeg.stderr.unwrap())?)
+    }
     info!("Output file generated");
 
     if let Some(mut stdout_file) = stdout_tempfile {

--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -290,38 +290,32 @@ impl FFmpegPreset {
                     FFmpegPreset::Av1 => bail!("'nvidia' hardware acceleration preset is not available in combination with the 'av1' codec preset"),
                     FFmpegPreset::H265 => {
                         input.extend(["-hwaccel", "cuvid", "-c:v", "h264_cuvid"]);
-                        output.extend(["-c:v", "hevc_nvenc"]);
+                        output.extend(["-c:v", "hevc_nvenc", "-c:a", "copy"]);
                     }
                     FFmpegPreset::H264 => {
                         input.extend(["-hwaccel", "cuvid", "-c:v", "h264_cuvid"]);
-                        output.extend(["-c:v", "h264_nvenc"]);
+                        output.extend(["-c:v", "h264_nvenc", "-c:a", "copy"]);
                     }
                     _ => ()
                 }
             } else {
                 match preset {
                     FFmpegPreset::Av1 => {
-                        output.extend(["-c:v", "libaom-av1"]);
+                        output.extend(["-c:v", "libaom-av1", "-c:a", "copy"]);
                     }
                     FFmpegPreset::H265 => {
-                        output.extend(["-c:v", "libx265"]);
+                        output.extend(["-c:v", "libx265", "-c:a", "copy"]);
                     }
                     FFmpegPreset::H264 => {
-                        output.extend(["-c:v", "libx264"]);
+                        output.extend(["-c:v", "libx264", "-c:a", "copy"]);
                     }
                     _ => (),
                 }
             }
         }
 
-        if input.is_empty() && output.is_empty() {
-            output.extend(["-c", "copy"])
-        } else {
-            if output.is_empty() {
-                output.extend(["-c", "copy"])
-            } else {
-                output.extend(["-c:a", "copy", "-c:s", "copy"])
-            }
+        if output.is_empty() {
+            output.extend(["-c:v", "copy", "-c:a", "copy"])
         }
 
         Ok((

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -1,4 +1,4 @@
-use crunchyroll_rs::media::VariantData;
+use crunchyroll_rs::media::{StreamSubtitle, VariantData};
 use crunchyroll_rs::{Episode, Locale, Media, Movie};
 use log::warn;
 use std::path::PathBuf;
@@ -10,6 +10,7 @@ pub struct Format {
     pub description: String,
 
     pub audio: Locale,
+    pub subtitles: Vec<StreamSubtitle>,
 
     pub duration: Duration,
     pub stream: VariantData,
@@ -31,12 +32,14 @@ impl Format {
         episode: &Media<Episode>,
         season_episodes: &Vec<Media<Episode>>,
         stream: VariantData,
+        subtitles: Vec<StreamSubtitle>,
     ) -> Self {
         Self {
             title: episode.title.clone(),
             description: episode.description.clone(),
 
             audio: episode.metadata.audio_locale.clone(),
+            subtitles,
 
             duration: episode.metadata.duration.to_std().unwrap(),
             stream,
@@ -78,6 +81,7 @@ impl Format {
 
             duration: movie.metadata.duration.to_std().unwrap(),
             stream,
+            subtitles: vec![],
 
             series_id: movie.metadata.movie_listing_id.clone(),
             series_name: movie.metadata.movie_listing_title.clone(),

--- a/crunchy-cli-core/src/utils/mod.rs
+++ b/crunchy-cli-core/src/utils/mod.rs
@@ -7,3 +7,4 @@ pub mod os;
 pub mod parse;
 pub mod sort;
 pub mod subtitle;
+pub mod video;

--- a/crunchy-cli-core/src/utils/subtitle.rs
+++ b/crunchy-cli-core/src/utils/subtitle.rs
@@ -1,5 +1,11 @@
+use crate::utils::os::tempfile;
+use anyhow::Result;
+use chrono::NaiveTime;
 use crunchyroll_rs::media::StreamSubtitle;
 use crunchyroll_rs::Locale;
+use regex::Regex;
+use std::io::Write;
+use tempfile::TempPath;
 
 #[derive(Clone)]
 pub struct Subtitle {
@@ -8,4 +14,106 @@ pub struct Subtitle {
     pub episode_id: String,
     pub forced: bool,
     pub primary: bool,
+}
+
+pub async fn download_subtitle(
+    subtitle: StreamSubtitle,
+    max_length: NaiveTime,
+) -> Result<TempPath> {
+    let tempfile = tempfile(".ass")?;
+    let (mut file, path) = tempfile.into_parts();
+
+    let mut buf = vec![];
+    subtitle.write_to(&mut buf).await?;
+    buf = fix_subtitle_look_and_feel(buf);
+    buf = fix_subtitle_length(buf, max_length);
+
+    file.write_all(buf.as_slice())?;
+
+    Ok(path)
+}
+
+/// Add `ScaledBorderAndShadows: yes` to subtitles; without it they look very messy on some video
+/// players. See [crunchy-labs/crunchy-cli#66](https://github.com/crunchy-labs/crunchy-cli/issues/66)
+/// for more information.
+fn fix_subtitle_look_and_feel(raw: Vec<u8>) -> Vec<u8> {
+    let mut script_info = false;
+    let mut new = String::new();
+
+    for line in String::from_utf8_lossy(raw.as_slice()).split('\n') {
+        if line.trim().starts_with('[') && script_info {
+            new.push_str("ScaledBorderAndShadow: yes\n");
+            script_info = false
+        } else if line.trim() == "[Script Info]" {
+            script_info = true
+        }
+        new.push_str(line);
+        new.push('\n')
+    }
+
+    new.into_bytes()
+}
+
+/// Fix the length of subtitles to a specified maximum amount. This is required because sometimes
+/// subtitles have an unnecessary entry long after the actual video ends with artificially extends
+/// the video length on some video players. To prevent this, the video length must be hard set. See
+/// [crunchy-labs/crunchy-cli#32](https://github.com/crunchy-labs/crunchy-cli/issues/32) for more
+/// information.
+fn fix_subtitle_length(raw: Vec<u8>, max_length: NaiveTime) -> Vec<u8> {
+    let re =
+        Regex::new(r#"^Dialogue:\s\d+,(?P<start>\d+:\d+:\d+\.\d+),(?P<end>\d+:\d+:\d+\.\d+),"#)
+            .unwrap();
+
+    // chrono panics if we try to format NaiveTime with `%2f` and the nano seconds has more than 2
+    // digits so them have to be reduced manually to avoid the panic
+    fn format_naive_time(native_time: NaiveTime) -> String {
+        let formatted_time = native_time.format("%f").to_string();
+        format!(
+            "{}.{}",
+            native_time.format("%T"),
+            if formatted_time.len() <= 2 {
+                native_time.format("%2f").to_string()
+            } else {
+                formatted_time.split_at(2).0.parse().unwrap()
+            }
+        )
+    }
+
+    let length_as_string = format_naive_time(max_length);
+    let mut new = String::new();
+
+    for line in String::from_utf8_lossy(raw.as_slice()).split('\n') {
+        if let Some(capture) = re.captures(line) {
+            let start = capture.name("start").map_or(NaiveTime::default(), |s| {
+                NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S.%f").unwrap()
+            });
+            let end = capture.name("end").map_or(NaiveTime::default(), |s| {
+                NaiveTime::parse_from_str(s.as_str(), "%H:%M:%S.%f").unwrap()
+            });
+
+            if start > max_length {
+                continue;
+            } else if end > max_length {
+                new.push_str(
+                    re.replace(
+                        line,
+                        format!(
+                            "Dialogue: {},{},",
+                            format_naive_time(start),
+                            &length_as_string
+                        ),
+                    )
+                    .to_string()
+                    .as_str(),
+                )
+            } else {
+                new.push_str(line)
+            }
+        } else {
+            new.push_str(line)
+        }
+        new.push('\n')
+    }
+
+    new.into_bytes()
 }

--- a/crunchy-cli-core/src/utils/video.rs
+++ b/crunchy-cli-core/src/utils/video.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use chrono::NaiveTime;
+use regex::Regex;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Get the length of a video. This is required because sometimes subtitles have an unnecessary entry
+/// long after the actual video ends with artificially extends the video length on some video players.
+/// To prevent this, the video length must be hard set. See
+/// [crunchy-labs/crunchy-cli#32](https://github.com/crunchy-labs/crunchy-cli/issues/32) for more
+/// information.
+pub fn get_video_length(path: PathBuf) -> Result<NaiveTime> {
+    let video_length = Regex::new(r"Duration:\s(?P<time>\d+:\d+:\d+\.\d+),")?;
+
+    let ffmpeg = Command::new("ffmpeg")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .arg("-y")
+        .args(["-i", path.to_str().unwrap()])
+        .output()?;
+    let ffmpeg_output = String::from_utf8(ffmpeg.stderr)?;
+    let caps = video_length.captures(ffmpeg_output.as_str()).unwrap();
+
+    Ok(NaiveTime::parse_from_str(caps.name("time").unwrap().as_str(), "%H:%M:%S%.f").unwrap())
+}


### PR DESCRIPTION
Until now, Crunchyroll always provided videos with subtitles burnt-in. But it seems that they starting to shutdown this kind of videos, at least for some languages. Italian for example has no hardsubbed videos for some series ([#81 (comment)](https://github.com/crunchy-labs/crunchy-cli/issues/81#issuecomment-1381687150)). To prevent such errors as in #81, this PR removes the logic to download the pre hardsubbed videos and burns in the subtitles itself via `ffmpeg`.

This includes some major changes:
- `ffmpeg` is now required for `download` too. Adding subtitles to a video cannot be done without it.
- The default file extension will change from `.ts` to `.mp4`. Mp4 is one of the few container formats which supports subtitles to be added as a separate stream which can be turned on and off (and not directly be burnt into the video as it's the only choice for most other formats). This has the advantage over `.ts` that the whole video doesn't need to be re-encoded which takes some time, especially with higher quality videos. All other formats will burn the subtitles into the video which consumes much time and cpu. It's now highly recommended to use mp4 as format for `download`. The subtitles in a mp4 file will have the ffmpeg `forced` flag/disposition which should show them in the most video players automatically but you might activate them manually in players which does not recognize this flag.
- Piping to stdout (with the `-o -` flag) (#69) isn't so fast anymore. In the past when the actual video download started, the piping process started immediately. But now this isn't possible anymore b/c ffmpeg requires the output file to be seekable in order to add subtitles (at least for mp4, which is the format which will be piped). To have this guaranteed when piping, `download` will create a temporary file which gets piped to stdout if the video content was fully written to it. This makes piping less powerful than before.