### PR TITLE
Skip existing files

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -122,6 +122,10 @@ pub struct Archive {
     #[arg(long)]
     no_subtitle_optimizations: bool,
 
+    #[arg(help = "Skip files which are already existing")]
+    #[arg(long, default_value_t = false)]
+    skip_existing: bool,
+
     #[arg(help = "Ignore interactive input")]
     #[arg(short, long, default_value_t = false)]
     yes: bool,
@@ -242,17 +246,24 @@ impl Execute for Archive {
             for (formats, mut subtitles) in archive_formats {
                 let (primary, additionally) = formats.split_first().unwrap();
 
-                let path = free_file(
-                    primary.format_path(
-                        if self.output.is_empty() {
-                            "{title}.mkv"
-                        } else {
-                            &self.output
-                        }
-                        .into(),
-                        true,
-                    ),
+                let formatted_path = primary.format_path(
+                    if self.output.is_empty() {
+                        "{title}.mkv"
+                    } else {
+                        &self.output
+                    }
+                    .into(),
+                    true,
                 );
+                let (path, changed) = free_file(formatted_path.clone());
+
+                if changed && self.skip_existing {
+                    debug!(
+                        "Skipping already existing file '{}'",
+                        formatted_path.to_string_lossy()
+                    );
+                    continue;
+                }
 
                 info!(
                     "Downloading {} to '{}'",

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -246,15 +246,7 @@ impl Execute for Archive {
             for (formats, mut subtitles) in archive_formats {
                 let (primary, additionally) = formats.split_first().unwrap();
 
-                let formatted_path = primary.format_path(
-                    if self.output.is_empty() {
-                        "{title}.mkv"
-                    } else {
-                        &self.output
-                    }
-                    .into(),
-                    true,
-                );
+                let formatted_path = primary.format_path((&self.output).into(), true);
                 let (path, changed) = free_file(formatted_path.clone());
 
                 if changed && self.skip_existing {

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -74,6 +74,10 @@ pub struct Download {
     #[arg(value_parser = FFmpegPreset::parse)]
     ffmpeg_preset: Vec<FFmpegPreset>,
 
+    #[arg(help = "Skip files which are already existing")]
+    #[arg(long, default_value_t = false)]
+    skip_existing: bool,
+
     #[arg(help = "Ignore interactive input")]
     #[arg(short, long, default_value_t = false)]
     yes: bool,
@@ -209,17 +213,24 @@ impl Execute for Download {
             }
 
             for format in formats {
-                let path = free_file(
-                    format.format_path(
-                        if self.output.is_empty() {
-                            "{title}.mkv"
-                        } else {
-                            &self.output
-                        }
-                        .into(),
-                        true,
-                    ),
+                let formatted_path = format.format_path(
+                    if self.output.is_empty() {
+                        "{title}.mkv"
+                    } else {
+                        &self.output
+                    }
+                    .into(),
+                    true,
                 );
+                let (path, changed) = free_file(formatted_path.clone());
+
+                if changed && self.skip_existing {
+                    debug!(
+                        "Skipping already existing file '{}'",
+                        formatted_path.to_string_lossy()
+                    );
+                    continue;
+                }
 
                 info!(
                     "Downloading {} to '{}'",

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -213,15 +213,7 @@ impl Execute for Download {
             }
 
             for format in formats {
-                let formatted_path = format.format_path(
-                    if self.output.is_empty() {
-                        "{title}.mkv"
-                    } else {
-                        &self.output
-                    }
-                    .into(),
-                    true,
-                );
+                let formatted_path = format.format_path((&self.output).into(), true);
                 let (path, changed) = free_file(formatted_path.clone());
 
                 if changed && self.skip_existing {

--- a/crunchy-cli-core/src/utils/os.rs
+++ b/crunchy-cli-core/src/utils/os.rs
@@ -36,10 +36,10 @@ pub fn tempfile<S: AsRef<str>>(suffix: S) -> io::Result<NamedTempFile> {
 }
 
 /// Check if the given path exists and rename it until the new (renamed) file does not exist.
-pub fn free_file(mut path: PathBuf) -> PathBuf {
+pub fn free_file(mut path: PathBuf) -> (PathBuf, bool) {
     // if it's a special file does not rename it
     if is_special_file(&path) {
-        return path;
+        return (path, false);
     }
 
     let mut i = 0;
@@ -55,7 +55,7 @@ pub fn free_file(mut path: PathBuf) -> PathBuf {
 
         path.set_file_name(format!("{} ({}).{}", filename, i, ext))
     }
-    path
+    (path, i != 0)
 }
 
 /// Check if the given path is a special file. On Linux this is probably a pipe and on Windows


### PR DESCRIPTION
This PR adds the `--skip-existing` flag (works for `download` as well as `archive`) (#67, #109). This skips output files which are already present and continues to download the next episode.
It also removes the behavior that the filename is set to the default when using `-o ''`.