### PR TITLE
(Re-)add `-l all` languages

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -366,12 +366,12 @@ async fn formats_from_series(
             .into_iter()
             .filter(|l| !season.iter().any(|s| s.metadata.audio_locales.contains(l)))
             .collect::<Vec<Locale>>();
-        for not_present in not_present_audio {
+        if !not_present_audio.is_empty() {
             error!(
                 "Season {} of series {} is not available with {} audio",
                 season.first().unwrap().metadata.season_number,
                 series.title,
-                not_present
+                not_present_audio.into_iter().map(|l| l.to_string()).collect::<Vec<String>>().join(", ")
             )
         }
 

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -1,7 +1,7 @@
 use crate::cli::log::tab_info;
 use crate::cli::utils::{
-    download_segments, find_multiple_seasons_with_same_number, find_resolution,
-    interactive_season_choosing, FFmpegPreset,
+    all_locale_in_locales, download_segments, find_multiple_seasons_with_same_number,
+    find_resolution, interactive_season_choosing, FFmpegPreset,
 };
 use crate::utils::context::Context;
 use crate::utils::format::Format;
@@ -132,7 +132,7 @@ pub struct Archive {
 
 #[async_trait::async_trait(?Send)]
 impl Execute for Archive {
-    fn pre_check(&self) -> Result<()> {
+    fn pre_check(&mut self) -> Result<()> {
         if !has_ffmpeg() {
             bail!("FFmpeg is needed to run this command")
         } else if PathBuf::from(&self.output)
@@ -150,6 +150,9 @@ impl Execute for Archive {
         {
             warn!("Skipping 'nvidia' hardware acceleration preset since no other codec preset was specified")
         }
+
+        self.locale = all_locale_in_locales(self.locale.clone());
+        self.subtitle = all_locale_in_locales(self.subtitle.clone());
 
         Ok(())
     }

--- a/crunchy-cli-core/src/cli/download.rs
+++ b/crunchy-cli-core/src/cli/download.rs
@@ -1,7 +1,7 @@
 use crate::cli::log::tab_info;
 use crate::cli::utils::{
-    download_segments, find_multiple_seasons_with_same_number, find_resolution,
-    interactive_season_choosing, FFmpegPreset,
+    download_segments, find_multiple_seasons_with_same_number,
+    find_resolution, interactive_season_choosing, FFmpegPreset,
 };
 use crate::utils::context::Context;
 use crate::utils::format::Format;
@@ -84,7 +84,7 @@ pub struct Download {
 
 #[async_trait::async_trait(?Send)]
 impl Execute for Download {
-    fn pre_check(&self) -> Result<()> {
+    fn pre_check(&mut self) -> Result<()> {
         if has_ffmpeg() {
             debug!("FFmpeg detected")
         } else if PathBuf::from(&self.output)

--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -1,7 +1,7 @@
 use crate::utils::context::Context;
 use anyhow::{bail, Result};
 use crunchyroll_rs::media::{Resolution, VariantData, VariantSegment};
-use crunchyroll_rs::{Media, Season};
+use crunchyroll_rs::{Locale, Media, Season};
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use lazy_static::lazy_static;
 use log::{debug, LevelFilter};
@@ -367,6 +367,20 @@ pub(crate) fn find_multiple_seasons_with_same_number(seasons: &Vec<Media<Season>
             None
         })
         .collect()
+}
+
+/// Check if [`Locale::Custom("all")`] is in the provided locale list and return [`Locale::all`] if
+/// so. If not, just return the provided locale list.
+pub(crate) fn all_locale_in_locales(locales: Vec<Locale>) -> Vec<Locale> {
+    if locales
+        .iter()
+        .find(|l| l.to_string().to_lowercase().trim() == "all")
+        .is_some()
+    {
+        Locale::all()
+    } else {
+        locales
+    }
 }
 
 pub(crate) fn interactive_season_choosing(seasons: Vec<Media<Season>>) -> Vec<Media<Season>> {

--- a/crunchy-cli-core/src/lib.rs
+++ b/crunchy-cli-core/src/lib.rs
@@ -16,10 +16,10 @@ pub use cli::{archive::Archive, download::Download, login::Login};
 
 #[async_trait::async_trait(?Send)]
 trait Execute {
-    fn pre_check(&self) -> Result<()> {
+    fn pre_check(&mut self) -> Result<()> {
         Ok(())
     }
-    async fn execute(self, ctx: Context) -> Result<()>;
+    async fn execute(mut self, ctx: Context) -> Result<()>;
 }
 
 #[derive(Debug, Parser)]
@@ -171,7 +171,7 @@ pub async fn cli_entrypoint() {
 
 /// Cannot be done in the main function. I wanted to return `dyn` [`Execute`] from the match but had to
 /// box it which then conflicts with [`Execute::execute`] which consumes `self`
-async fn execute_executor(executor: impl Execute, ctx: Context) {
+async fn execute_executor(mut executor: impl Execute, ctx: Context) {
     if let Err(err) = executor.pre_check() {
         error!("Misconfigurations detected: {}", err);
         std::process::exit(1)


### PR DESCRIPTION
In v2 you could pass `-l all` and `-s all` to download audio/subtitles with every audio available. This PR (re-)adds this functionality (#110).