### PR TITLE
Don't remove the subtitles if the video is detected to be identical

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -298,10 +298,11 @@ impl Execute for Archive {
 
                 video_paths.push((download_video(&ctx, primary, false).await?, primary));
                 for additional in additionally {
+                    let identical_video = additionally
+                        .iter()
+                        .all(|a| a.stream.bandwidth == primary.stream.bandwidth);
                     let only_audio = match self.merge {
-                        MergeBehavior::Auto => additionally
-                            .iter()
-                            .all(|a| a.stream.bandwidth == primary.stream.bandwidth),
+                        MergeBehavior::Auto => identical_video,
                         MergeBehavior::Audio => true,
                         MergeBehavior::Video => false,
                     };
@@ -312,8 +313,8 @@ impl Execute for Archive {
                         video_paths.push((path, additional))
                     }
 
-                    // Remove subtitles of deleted video
-                    if only_audio {
+                    // Remove subtitles of forcibly deleted video
+                    if matches!(self.merge, MergeBehavior::Audio) && !identical_video {
                         subtitles.retain(|s| s.episode_id != additional.episode_id);
                     }
                 }


### PR DESCRIPTION
This fixes a bug introduced in #97.

If a video stream is detected to be identical and is getting removed due to the merge behavior set to "auto" (or "audio" and the videos aren't identical), the subtitles may still be kept.

I'm not sure if it's a problem that the name of the subtitle stream in the mkv file might refer to a video stream that got deleted. E.g. "German [Video: Japanese]" and the Japanese video was removed.