### PR TITLE
bugfix: btreemap skips duplicate ep nums

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.metadata.episode.clone())
+                .entry(episode.id.clone())
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -383,7 +383,7 @@ async fn formats_from_series(
     }
 
     #[allow(clippy::type_complexity)]
-    let mut result: BTreeMap<u32, BTreeMap<u32, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
+    let mut result: BTreeMap<u32, BTreeMap<String, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
     let mut primary_season = true;
     for season in seasons {
         let episodes = season.episodes().await?;
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.metadata.episode_number)
+                .entry(episode.metadata.episode.clone())
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -383,7 +383,7 @@ async fn formats_from_series(
     }
 
     #[allow(clippy::type_complexity)]
-    let mut result: BTreeMap<u32, BTreeMap<String, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
+    let mut result: BTreeMap<u32, BTreeMap<u32, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
     let mut primary_season = true;
     for season in seasons {
         let episodes = season.episodes().await?;
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.id.clone())
+                .entry((episode.metadata.sequence_number * 100.0) as u32)
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;


### PR DESCRIPTION
Related to a comment in #118 (the language thing is separate and still bugged, tested on `your-lie-in-april`)

> The problem is that Crunchyroll has different episodes for the first Re:Zero episode. In some language, the first episode is split in two ~24 minute parts, other languages are providing it as a long ~50 minute episode. This distracts the cli.

EDIT: In the case of re:zero, the video tracks aren't actually duplicated - it's just that the tracks for E1A and E1B are collapsed into the same file. However, that behaviour can be confusing for the user.

As far as I can tell, the only purpose of this key in the `BTreeMap` is to maintain the order of episodes. It doesn't seem like "deduplicating `episode_number`" is part of the intention here. 

Didn't check if this has any side-effects or whether `sequence_number` has any good guarantees on existence, but I do know this `episode_number` field is going to keep messing things up. I'd imagine Crunchyroll also needs this `sequence_number` field to determine the episode order - so it should be safe to depend on it. 

Picked `100.0` arbitrarily, you should still have plenty of room in f32, but who knows when an episode will be split into >100 parts. 

As per examples below, we can't depend on `episode_number` (can be null), `episode` (can be empty string), or `id` (doesn't do anything for order)

<details>
<summary> re:zero example </summary>

```json
{
    "id": "GRE5K0K36",
    "episode_number": 1,
    "episode": "1A",
    "title": "The End of the Beginning and the Beginning of the End (Part 1)",
    "identifier": "GRGG9798R|S1|E0.5",
    "season_number": 1,
    "sequence_number": 0.5
},
{
    "id": "G69PM9M9Y",
    "episode_number": 1,
    "episode": "1B",
    "title": "The End of the Beginning and the Beginning of the End (Part 2)",
    "season_number": 1,
    "sequence_number": 1,
    "season_id": "G609GZG26"
}
```

Broken
```
:: ✔ Loaded series information for url 1                                                                                                                                    
:: Re:ZERO -Starting Life in Another World- Season 1 (Re:ZERO -Starting Life in Another World-)
:: 	1. The End of the Beginning and the Beginning of the End (Part 1) » 1920x1080px, 23.97 FPS (S01E0.5)
:: 	2. Reunion with the Witch » 1920x1080px, 23.97 FPS (S01E02)
```

Fixed
```
...
:: ✔ Loaded series information for url 1                                                                                                                                    
:: Re:ZERO -Starting Life in Another World- Season 1 (Re:ZERO -Starting Life in Another World-)
:: 	1. The End of the Beginning and the Beginning of the End (Part 1) » 1920x1080px, 23.97 FPS (S01E0.5)
:: 	2. The End of the Beginning and the Beginning of the End (Part 2) » 1920x1080px, 23.97 FPS (S01E01)
:: 	3. Reunion with the Witch » 1920x1080px, 23.97 FPS (S01E02)
```
</details>

<details>
<summary> aot example </summary>

```json
{
    "id": "GYG5QDVWY",
    "identifier": "GR751KNZY|S1|E0",
    "sequence_number": 0.5,
    "episode_number": null,
    "title": "PV",
    "episode": ""
},
{
    "id": "GYJQK14E6",
    "sequence_number": 13,
    "episode": "13",
    "episode_number": 13,
    "title": "Primal Desires - The Battle for Trost (9)",
    "identifier": "GR751KNZY|S1|E13"
}
{
    "id": "GYK5KX14R",
    "sequence_number": 13.5,
    "episode": "13.5",
    "episode_number": null,
    "title": "Since That Day",
    "identifier": "GR751KNZY|S1|E13.5"
},
```
Broken
```
:: 	13. Wound - The Battle for Trost (8) » 1920x1080px, 23.97 FPS (S01E12)
:: 	14. Primal Desires - The Battle for Trost (9) » 1920x1080px, 23.97 FPS (S01E13)
:: 	15. Still Can't See - Night Before the Counteroffensive (1) » 1920x1080px, 23.97 FPS (S01E14)
```
Fixed
```
:: 	13. Wound - The Battle for Trost (8) » 1920x1080px, 23.97 FPS (S01E12)
:: 	14. Primal Desires - The Battle for Trost (9) » 1920x1080px, 23.97 FPS (S01E13)
:: 	15. Since That Day » 1920x1080px, 23.97 FPS (S01E13.5)
:: 	16. Still Can't See - Night Before the Counteroffensive (1) » 1920x1080px, 23.97 FPS (S01E14)
```
</details>

Hoping it's just a one-liner