### PR TITLE
bugfix: duplicate ep numbers archived into same file

### DIFF
--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.metadata.episode.clone())
+                .entry(episode.id.clone())
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -383,7 +383,7 @@ async fn formats_from_series(
     }
 
     #[allow(clippy::type_complexity)]
-    let mut result: BTreeMap<u32, BTreeMap<u32, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
+    let mut result: BTreeMap<u32, BTreeMap<String, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
     let mut primary_season = true;
     for season in seasons {
         let episodes = season.episodes().await?;
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.metadata.episode_number)
+                .entry(episode.metadata.episode.clone())
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -383,7 +383,7 @@ async fn formats_from_series(
     }
 
     #[allow(clippy::type_complexity)]
-    let mut result: BTreeMap<u32, BTreeMap<String, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
+    let mut result: BTreeMap<u32, BTreeMap<u32, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
     let mut primary_season = true;
     for season in seasons {
         let episodes = season.episodes().await?;
@@ -414,7 +414,7 @@ async fn formats_from_series(
             let (ref mut formats, subtitles) = result
                 .entry(season.metadata.season_number)
                 .or_insert_with(BTreeMap::new)
-                .entry(episode.id.clone())
+                .entry((episode.metadata.sequence_number * 100.0) as u32)
                 .or_insert_with(|| (vec![], vec![]));
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;

--- a/crunchy-cli-core/src/cli/archive.rs
+++ b/crunchy-cli-core/src/cli/archive.rs
@@ -16,7 +16,6 @@ use anyhow::{bail, Result};
 use crunchyroll_rs::media::Resolution;
 use crunchyroll_rs::{Locale, Media, MediaCollection, Series};
 use log::{debug, error, info};
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use tempfile::TempPath;
@@ -383,7 +382,7 @@ async fn formats_from_series(
     }
 
     #[allow(clippy::type_complexity)]
-    let mut result: BTreeMap<u32, BTreeMap<u32, (Vec<Format>, Vec<Subtitle>)>> = BTreeMap::new();
+    let mut result: Vec<(Vec<Format>, Vec<Subtitle>)> = Vec::new();
     let mut primary_season = true;
     for season in seasons {
         let episodes = season.episodes().await?;
@@ -411,11 +410,8 @@ async fn formats_from_series(
                 )
             };
 
-            let (ref mut formats, subtitles) = result
-                .entry(season.metadata.season_number)
-                .or_insert_with(BTreeMap::new)
-                .entry((episode.metadata.sequence_number * 100.0) as u32)
-                .or_insert_with(|| (vec![], vec![]));
+            let mut formats: Vec<Format> = Vec::new();
+            let mut subtitles: Vec<Subtitle> = Vec::new();
             subtitles.extend(archive.subtitle.iter().filter_map(|l| {
                 let stream_subtitle = streams.subtitles.get(l).cloned()?;
                 let subtitle = Subtitle {
@@ -428,12 +424,14 @@ async fn formats_from_series(
                 Some(subtitle)
             }));
             formats.push(Format::new_from_episode(episode, &episodes, stream, vec![]));
+
+            result.push((formats, subtitles));
         }
 
         primary_season = false;
     }
 
-    Ok(result.into_values().flat_map(|v| v.into_values()).collect())
+    Ok(result)
 }
 
 async fn download_video(ctx: &Context, format: &Format, only_audio: bool) -> Result<TempPath> {


### PR DESCRIPTION
(Closing #135 bc I pushed to the wrong branch)

Related to a comment in #118 (the language thing is separate and still bugged, tested on `your-lie-in-april`)

> The problem is that Crunchyroll has different episodes for the first Re:Zero episode. In some language, the first episode is split in two ~24 minute parts, other languages are providing it as a long ~50 minute episode. This distracts the cli.

In the case of re:zero, the video tracks aren't actually duplicated - it's just that the tracks for E1A and E1B are collapsed into the same file. However, that behaviour can be confusing for the user

The BTreeMap doesn't seem necessary here since it was already sorted and filtered.

<details>
<summary> seems fine on rezero </summary>

```
:: ✔ Logging in                                                                                                                                                                              :: ✔ Parsed url 1                                                                                                                                                                            :: → Season 3 of series Re:ZERO -Starting Life in Another World- is not available with ja-JP audio
:: → Season 9 of series Re:ZERO -Starting Life in Another World- is not available with ja-JP audio
:: → Season 12 of series Re:ZERO -Starting Life in Another World- is not available with ja-JP audio
:: ✔ Loaded series information for url 1                                                                                                                                                     :: Re:ZERO -Starting Life in Another World- Season 1 (Re:ZERO -Starting Life in Another World-)
:: 	1. The End of the Beginning and the Beginning of the End (Part 1) » 1920x1080px, 23.97 FPS (S01E0.5)
:: 	2. The End of the Beginning and the Beginning of the End (Part 2) » 1920x1080px, 23.97 FPS (S01E01)
:: 	3. Reunion with the Witch » 1920x1080px, 23.97 FPS (S01E02)
:: 	4. Starting Life from Zero in Another World » 1920x1080px, 23.97 FPS (S01E03)
:: 	5. The Happy Roswaal Mansion Family » 1920x1080px, 23.97 FPS (S01E04)
:: 	6. The Morning of Our Promise Is Still Distant » 1920x1080px, 23.97 FPS (S01E05)
:: 	7. The Sound of Chains » 1920x1080px, 23.97 FPS (S01E06)
:: 	8. Natsuki Subaru's Restart » 1920x1080px, 23.97 FPS (S01E07)
:: 	9. I Cried, Cried My Lungs Out, and Stopped Crying » 1920x1080px, 23.97 FPS (S01E08)
:: 	10. The Meaning of Courage » 1920x1080px, 23.97 FPS (S01E09)
:: 	11. Fanatical Methods Like a Demon » 1920x1080px, 23.97 FPS (S01E10)
:: 	12. Rem » 1920x1080px, 23.97 FPS (S01E11)
:: 	13. Return to the Capital » 1920x1080px, 23.97 FPS (S01E12)
:: 	14. Self-Proclaimed Knight Natsuki Subaru » 1920x1080px, 23.97 FPS (S01E13)
:: 	15. The Sickness Called Despair » 1920x1080px, 23.97 FPS (S01E14)
:: 	16. The Outside of Madness » 1920x1080px, 23.97 FPS (S01E15)
:: 	17. The Greed of a Pig » 1920x1080px, 23.97 FPS (S01E16)
:: 	18. Disgrace in the Extreme » 1920x1080px, 23.97 FPS (S01E17)
:: 	19. From Zero » 1920x1080px, 23.97 FPS (S01E18)
:: 	20. Battle Against the White Whale » 1920x1080px, 23.97 FPS (S01E19)
:: 	21. Wilhelm van Astrea » 1920x1080px, 23.97 FPS (S01E20)
:: 	22. A Wager That Defies Despair » 1920x1080px, 23.97 FPS (S01E21)
:: 	23. A Flash of Sloth » 1920x1080px, 23.97 FPS (S01E22)
:: 	24. Nefarious Sloth » 1920x1080px, 23.97 FPS (S01E23)
:: 	25. The Self-Proclaimed Knight and the Greatest Knight » 1920x1080px, 23.97 FPS (S01E24)
:: 	26. That's All This Story Is About » 1920x1080px, 23.97 FPS (S01E25)
:: Re:ZERO -Starting Life in Another World- Season 2 (Re:ZERO -Starting Life in Another World- Season 2)
:: 	1. Each One's Promise » 1920x1080px, 23.97 FPS (S02E26)
:: 	2. The Next Location » 1920x1080px, 23.97 FPS (S02E27)
:: 	3. The Long-Awaited Reunion » 1920x1080px, 23.97 FPS (S02E28)
:: 	4. Parent and Child » 1920x1080px, 23.97 FPS (S02E29)
:: 	5. A Step Forward » 1920x1080px, 23.97 FPS (S02E30)
:: 	6. The Maiden's Gospel » 1920x1080px, 23.97 FPS (S02E31)
:: 	7. Friend » 1920x1080px, 23.97 FPS (S02E32)
:: 	8. The Value of Life » 1920x1080px, 23.97 FPS (S02E33)
:: 	9. Love Love Love Love Love Love You » 1920x1080px, 23.97 FPS (S02E34)
:: 	10. I Know Hell » 1920x1080px, 23.97 FPS (S02E35)
:: 	11. The Taste of Death » 1920x1080px, 23.97 FPS (S02E36)
:: 	12. The Witches' Tea Party » 1920x1080px, 23.97 FPS (S02E37)
:: 	13. The Sounds That Make You Want to Cry » 1920x1080px, 23.97 FPS (S02E38)
:: 	14. STRAIGHT BET » 1920x1080px, 23.97 FPS (S02E39)
:: 	15. Otto Suwen / A Reason to Believe » 1920x1080px, 23.97 FPS (S02E40)
:: 	16. Nobody Can Lift a Quain Stone Alone » 1920x1080px, 23.97 FPS (S02E41)
:: 	17. A Journey Through Memories » 1920x1080px, 23.97 FPS (S02E42)
:: 	18. The Day Betelgeuse Laughed » 1920x1080px, 23.97 FPS (S02E43)
:: 	19. The Permafrost of Elior Forest » 1920x1080px, 23.97 FPS (S02E44)
:: 	20. The Beginning of the Sanctuary and the Beginning of the End » 1920x1080px, 23.97 FPS (S02E45)
:: 	21. Reunion of Roars » 1920x1080px, 23.97 FPS (S02E46)
:: 	22. Happiness Reflected on the Water's Surface » 1920x1080px, 23.97 FPS (S02E47)
:: 	23. Love Me Down to My Blood and Guts » 1920x1080px, 23.97 FPS (S02E48)
:: 	24. Choose Me » 1920x1080px, 23.97 FPS (S02E49)
:: 	25. Offbeat Steps Under the Moonlight » 1920x1080px, 23.97 FPS (S02E50)
:: Re:ZERO -Starting Life in Another World- Season 32 (Re:ZERO -Starting Life in Another World- Director's Cut)
:: 	1. The End of the Beginning and the Beginning of the End » 1920x1080px, 23.97 FPS (S32E01)
:: 	2. Reunion with the Witch \ Starting Life from Zero in Another World » 1920x1080px, 23.97 FPS (S32E02)
:: 	3. The Happy Roswaal Mansion Family \ The Morning of Our Promise Is Still Distant » 1920x1080px, 23.97 FPS (S32E03)
:: 	4. The Sound of Chains \ Natsuki Subaru's Restart » 1920x1080px, 23.97 FPS (S32E04)
:: 	5. I Cried, Cried My Lungs Out, and Stopped Crying \ The Meaning of Courage » 1920x1080px, 23.97 FPS (S32E05)
:: 	6. Fanatical Methods Like a Demon \ Rem » 1920x1080px, 23.97 FPS (S32E06)
:: 	7. Memory Snow » 1920x1080px, 23.97 FPS (S32E6.5)
:: 	8. Return to the Capital \ Self-Proclaimed Knight Natsuki Subaru » 1920x1080px, 23.97 FPS (S32E07)
:: 	9. The Sickness Called Despair \ The Outside of Madness » 1920x1080px, 23.97 FPS (S32E08)
:: 	10. The Greed of a Pig \ Disgrace in the Extreme » 1920x1080px, 23.97 FPS (S32E09)
:: 	11. From Zero \ Battle Against the White Whale » 1920x1080px, 23.97 FPS (S32E10)
:: 	12. Wilhelm van Astrea \ A Wager That Defies Despair » 1920x1080px, 23.97 FPS (S32E11)
:: 	13. A Flash of Sloth \ Nefarious Sloth » 1920x1080px, 23.97 FPS (S32E12)
:: 	14. The Self-Proclaimed Knight and the Greatest Knight \ That's All This Story Is About » 1920x1080px, 23.97 FPS (S32E13)
:: Re:ZERO -Starting Life in Another World- Season 33 (Re:ZERO -Starting Life in Another World- The Frozen Bond)
:: 	1. The Frozen Bond » 1920x1080px, 23.97 FPS (S33E00)
:: Downloading The End of the Beginning and the Beginning of the End (Part 1) to 'S01E01 - The End of the Beginning and the Beginning of the End (Part 1).mkv'
:: 	Episode: S01E0.5
:: 	Audio: ja-JP (primary), 
:: 	Subtitle: en-US
:: 	Resolution: 1920x1080
:: 	FPS: 23.97
:: Download ja-JP   1.47 GiB  72.02 MiB/s [############################################################################################################################################] 100%:: ✔ Mkv generated                                               
```
</details>

<details>
<summary>seems fine on aot example</summary>

```
:: ✔ Logging in                                                                                                                                                                              
:: ✔ Parsed url 1                                                                                                                                                                            
:: ✔ Loaded series information for url 1                                                                                                                                                     :: Attack on Titan Season 1 (Attack on Titan)
:: 	1. PV » 1920x1080px, 23.98 FPS (S01E0.5)
:: 	2. To You, 2,000 Years in the Future -The Fall of Zhiganshina (1) » 1920x1080px, 23.97 FPS (S01E01)
:: 	3. That Day - The Fall of Zhiganshina (2) » 1920x1080px, 23.97 FPS (S01E02)
:: 	4. A Dim Light in the Darkness of Despair - Humanity Rises Again (1) » 1920x1080px, 23.97 FPS (S01E03)
:: 	5. Night of the Graduation Ceremony - Humanity Rises Again (2) » 1920x1080px, 23.97 FPS (S01E04)
:: 	6. First Battle - Battle of Trost (1) » 1920x1080px, 23.97 FPS (S01E05)
:: 	7. The World the Girl Saw - Battle for Trost (2) » 1920x1080px, 23.97 FPS (S01E06)
:: 	8. The Small Blade - The Battle for Trost (3) » 1920x1080px, 23.97 FPS (S01E07)
:: 	9. Hearing the Heartbeat - The Battle for Trost (4) » 1920x1080px, 23.97 FPS (S01E08)
:: 	10. Where the Left Arm Went  - The Battle for Trost (5) » 1920x1080px, 23.97 FPS (S01E09)
:: 	11. Response - The Battle for Trost (6) » 1920x1080px, 23.97 FPS (S01E10)
:: 	12. Icon - The Battle for Trost (7) » 1920x1080px, 23.97 FPS (S01E11)
:: 	13. Wound - The Battle for Trost (8) » 1920x1080px, 23.97 FPS (S01E12)
:: 	14. Primal Desires - The Battle for Trost (9) » 1920x1080px, 23.97 FPS (S01E13)
:: 	15. Since That Day » 1920x1080px, 23.97 FPS (S01E13.5)
:: 	16. Still Can't See - Night Before the Counteroffensive (1) » 1920x1080px, 23.97 FPS (S01E14)
:: 	17. Special Ops Squad - Night Before the Counteroffensive (2) » 1920x1080px, 23.97 FPS (S01E15)
:: 	18. What Should Be Done - Night Before the Counteroffensive (3) » 1920x1080px, 23.97 FPS (S01E16)
:: 	19. Female Titan - 57th Expedition Beyond the Walls (1) » 1920x1080px, 23.97 FPS (S01E17)
:: 	20. Forest of Giant Trees - 57th Expedition Beyond the Walls (2) » 1920x1080px, 23.97 FPS (S01E18)
:: 	21. Bite - 57th Expedition Beyond the Walls (3) » 1920x1080px, 23.97 FPS (S01E19)
:: 	22. Erwin Smith - 57th Expedition Beyond the Walls (4) » 1920x1080px, 23.97 FPS (S01E20)
:: 	23. Crushing Blow - 57th Expedition Beyond the Walls (5) » 1920x1080px, 23.97 FPS (S01E21)
:: 	24. The Defeated - 57th Expedition Beyond the Walls (6) » 1920x1080px, 23.97 FPS (S01E22)
:: 	25. Smile - Raid on Stohess District (1) » 1920x1080px, 23.97 FPS (S01E23)
:: 	26. Mercy - Raid on Stohess District (2) » 1920x1080px, 23.97 FPS (S01E24)
:: 	27. The Wall - Raid on Stohess District (3) » 1920x1080px, 23.97 FPS (S01E25)
:: Attack on Titan Season 2 (Attack on Titan Season 2)
:: 	1. Beast Titan » 1920x1080px, 23.97 FPS (S02E26)
:: 	2. I'm Home » 1920x1080px, 23.97 FPS (S02E27)
:: 	3. Southwestward » 1920x1080px, 23.97 FPS (S02E28)
:: 	4. Soldier » 1920x1080px, 23.97 FPS (S02E29)
:: 	5. Historia » 1920x1080px, 23.97 FPS (S02E30)
:: 	6. Warrior » 1920x1080px, 23.97 FPS (S02E31)
:: 	7. Close Combat » 1920x1080px, 23.97 FPS (S02E32)
:: 	8. The Hunters » 1920x1080px, 23.97 FPS (S02E33)
:: 	9. Opening » 1920x1080px, 23.97 FPS (S02E34)
:: 	10. Children » 1920x1080px, 23.97 FPS (S02E35)
:: 	11. Charge » 1920x1080px, 23.97 FPS (S02E36)
:: 	12. Scream » 1920x1080px, 23.97 FPS (S02E37)
:: Attack on Titan Season 3 (Attack on Titan Season 3)
:: 	1. Smoke Signal » 1920x1080px, 23.97 FPS (S03E38)
:: 	2. Pain » 1920x1080px, 23.97 FPS (S03E39)
:: 	3. Old Story » 1920x1080px, 23.97 FPS (S03E40)
:: 	4. Trust » 1920x1080px, 23.97 FPS (S03E41)
:: 	5. Reply » 1920x1080px, 23.97 FPS (S03E42)
:: 	6. Sin » 1920x1080px, 23.97 FPS (S03E43)
:: 	7. Wish » 1920x1080px, 23.97 FPS (S03E44)
:: 	8. Outside the Walls of Orvud District » 1920x1080px, 23.97 FPS (S03E45)
:: 	9. Ruler of the Walls » 1920x1080px, 23.97 FPS (S03E46)
:: 	10. Friends » 1920x1080px, 23.97 FPS (S03E47)
:: 	11. Bystander » 1920x1080px, 23.97 FPS (S03E48)
:: 	12. Night of the Battle to Retake the Wall » 1920x1080px, 23.97 FPS (S03E49)
:: 	13. The Town Where Everything Began » 1920x1080px, 23.97 FPS (S03E50)
:: 	14. Thunder Spears » 1920x1080px, 23.97 FPS (S03E51)
:: 	15. Descent » 1920x1080px, 23.97 FPS (S03E52)
:: 	16. Perfect Game » 1920x1080px, 23.97 FPS (S03E53)
:: 	17. Hero » 1920x1080px, 23.97 FPS (S03E54)
:: 	18. Midnight Sun » 1920x1080px, 23.97 FPS (S03E55)
:: 	19. The Basement » 1920x1080px, 23.97 FPS (S03E56)
:: 	20. That Day » 1920x1080px, 23.97 FPS (S03E57)
:: 	21. Attack Titan » 1920x1080px, 23.97 FPS (S03E58)
:: 	22. The Other Side of the Wall » 1920x1080px, 23.97 FPS (S03E59)
:: Attack on Titan Season 4 (Attack on Titan Final Season)
:: 	1. The Other Side of the Sea » 1920x1080px, 23.97 FPS (S04E60)
:: 	2. Midnight Train » 1920x1080px, 23.97 FPS (S04E61)
:: 	3. The Door of Hope » 1920x1080px, 23.97 FPS (S04E62)
:: 	4. From One Hand to Another » 1920x1080px, 23.97 FPS (S04E63)
:: 	5. Declaration of War » 1920x1080px, 23.97 FPS (S04E64)
:: 	6. The War Hammer Titan » 1920x1080px, 23.97 FPS (S04E65)
:: 	7. Assault » 1920x1080px, 23.97 FPS (S04E66)
:: 	8. Assassin's Bullet » 1920x1080px, 23.97 FPS (S04E67)
:: 	9. Brave Volunteers » 1920x1080px, 23.97 FPS (S04E68)
:: 	10. A Sound Argument » 1920x1080px, 23.97 FPS (S04E69)
:: 	11. Deceiver » 1920x1080px, 23.97 FPS (S04E70)
:: 	12. Guides » 1920x1080px, 23.97 FPS (S04E71)
:: 	13. Children of the Forest » 1920x1080px, 23.97 FPS (S04E72)
:: 	14. Savagery » 1920x1080px, 23.97 FPS (S04E73)
:: 	15. Sole Salvation » 1920x1080px, 23.97 FPS (S04E74)
:: 	16. Above and Below » 1920x1080px, 23.97 FPS (S04E75)
:: 	17. Judgment » 1920x1080px, 23.97 FPS (S04E76)
:: 	18. Sneak Attack » 1920x1080px, 23.97 FPS (S04E77)
:: 	19. Two Brothers » 1920x1080px, 23.97 FPS (S04E78)
:: 	20. Memories of the Future » 1920x1080px, 23.97 FPS (S04E79)
:: 	21. From You, 2,000 Years Ago » 1920x1080px, 23.97 FPS (S04E80)
:: 	22. Thaw » 1920x1080px, 23.97 FPS (S04E81)
:: 	23. Sunset » 1920x1080px, 23.97 FPS (S04E82)
:: 	24. Pride » 1920x1080px, 23.97 FPS (S04E83)
:: 	25. Night of the End » 1920x1080px, 23.97 FPS (S04E84)
:: 	26. Traitor » 1920x1080px, 23.97 FPS (S04E85)
:: 	27. Retrospective » 1920x1080px, 23.97 FPS (S04E86)
:: 	28. The Dawn of Humanity » 1920x1080px, 23.97 FPS (S04E87)
:: Attack on Titan Season 6 (Attack on Titan OADs)
:: 	1. Ilse's Notebook: Memoirs of a Scout Regiment Member » 1920x1080px, 23.97 FPS (S06E01)
:: 	2. The Sudden Visitor: The Torturous Curse of Youth » 1920x1080px, 23.97 FPS (S06E02)
:: 	3. Distress » 1920x1080px, 23.97 FPS (S06E03)
:: 	4. No Regrets: Part 1 » 1920x1080px, 23.97 FPS (S06E04)
:: 	5. No Regrets: Part 2 » 1920x1080px, 23.97 FPS (S06E05)
:: 	6. Lost Girls: Wall Sina, Goodbye: Part 1 » 1920x1080px, 23.97 FPS (S06E06)
:: 	7. Lost Girls: Wall Sina, Goodbye: Part 2 » 1920x1080px, 23.97 FPS (S06E07)
:: 	8. Lost Girls: Lost in the Cruel World » 1920x1080px, 23.97 FPS (S06E08)
```
</details>
