### PR TITLE
Fix offset in interactive season choosing

### DIFF
--- a/crunchy-cli-core/src/cli/utils.rs
+++ b/crunchy-cli-core/src/cli/utils.rs
@@ -646,7 +646,7 @@ pub(crate) fn interactive_season_choosing(seasons: Vec<Media<Season>>) -> Vec<Me
         let mut nums = vec![];
         for capture in input_regex.captures_iter(&user_input) {
             if let Some(single) = capture.name("single") {
-                nums.push(single.as_str().parse().unwrap());
+                nums.push(single.as_str().parse::<usize>().unwrap() - 1);
             } else {
                 let range_from = capture.name("range_from");
                 let range_to = capture.name("range_to");


### PR DESCRIPTION
Without this, the input for a single season is always offset by 1.