### PR TITLE
Fix offset in relative episode number

### DIFF
--- a/crunchy-cli-core/src/archive/filter.rs
+++ b/crunchy-cli-core/src/archive/filter.rs
@@ -222,7 +222,8 @@ impl Filter for ArchiveFilter {
                 .get(&episode.season_number)
                 .unwrap()
                 .iter()
-                .position(|id| id == &episode.id);
+                .position(|id| id == &episode.id)
+                .map(|index| index + 1);
             if relative_episode_number.is_none() {
                 warn!(
                     "Failed to get relative episode number for episode {} ({}) of {} season {}",

--- a/crunchy-cli-core/src/download/filter.rs
+++ b/crunchy-cli-core/src/download/filter.rs
@@ -174,7 +174,8 @@ impl Filter for DownloadFilter {
                 .get(&episode.season_number)
                 .unwrap()
                 .iter()
-                .position(|id| id == &episode.id);
+                .position(|id| id == &episode.id)
+                .map(|index| index + 1);
             if relative_episode_number.is_none() {
                 warn!(
                     "Failed to get relative episode number for episode {} ({}) of {} season {}",


### PR DESCRIPTION
Right now, crunchy-cli would produce "00" for the first episode in a season (using `{relative_episode_number}`). However, it is probably meant to start at "01".