### PR TITLE
Check for remaining disk space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "ctrlc",
  "derive_setters",
  "dirs",
+ "fs2",
  "indicatif",
  "lazy_static",
  "log",
@@ -674,6 +675,16 @@ name = "fs-err"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-channel"

--- a/crunchy-cli-core/Cargo.toml
+++ b/crunchy-cli-core/Cargo.toml
@@ -13,6 +13,7 @@ crunchyroll-rs = { version = "0.3", features = ["dash-stream"] }
 ctrlc = "3.2"
 dirs = "5.0"
 derive_setters = "0.1"
+fs2 = "0.4"
 indicatif = "0.17"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }


### PR DESCRIPTION
This PR adds a check if the remaining disk space is enough to download episodes (#150). This could be used as a hint what could be the cause of errors like #153 which is pretty unintelligible without context. The calculation is not 100% accurate as the real file size can only be determined exactly after it has been completely downloaded and merged into the final video file.