### PR TITLE
Fix rate limiting error for episodes and movies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "crunchyroll-rs"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be975d4a27439853f6e80311b497e910fc49fd24525afdc12ca27ace18b84eeb"
+checksum = "b75b403a64b4cc8ed9a96cb16588475a93cb5c8643cf960907a54ae6f6ac3f0d"
 dependencies = [
  "aes",
  "async-trait",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "crunchyroll-rs-internal"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d71a343838c462ace0531b2f5556fd1ea6b677d7a3e61ac28251e87d158c47"
+checksum = "d91a9978a505750f606a1fcf1efd5970d20521310e886839f2ad95c31354e54e"
 dependencies = [
  "darling 0.14.4",
  "quote",

--- a/crunchy-cli-core/Cargo.toml
+++ b/crunchy-cli-core/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 clap = { version = "4.2", features = ["derive", "string"] }
 chrono = "0.4"
-crunchyroll-rs = { version = "0.3.3", features = ["dash-stream"] }
+crunchyroll-rs = { version = "0.3.4", features = ["dash-stream"] }
 ctrlc = "3.2"
 dirs = "5.0"
 derive_setters = "0.1"

--- a/crunchy-cli-core/src/lib.rs
+++ b/crunchy-cli-core/src/lib.rs
@@ -54,8 +54,7 @@ pub struct Cli {
 
     #[arg(help = "Use a proxy to route all traffic through")]
     #[arg(long_help = "Use a proxy to route all traffic through. \
-            Make sure that the proxy can either forward TLS requests, which is needed to bypass the (cloudflare) bot protection, or that it is configured so that the proxy can bypass the protection itself"
-    )]
+            Make sure that the proxy can either forward TLS requests, which is needed to bypass the (cloudflare) bot protection, or that it is configured so that the proxy can bypass the protection itself")]
     #[clap(long)]
     #[arg(value_parser = crate::utils::clap::clap_parse_proxy)]
     proxy: Option<Proxy>,

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use chrono::Duration;
 use crunchyroll_rs::media::{Resolution, Stream, Subtitle, VariantData};
 use crunchyroll_rs::{Concert, Episode, Locale, MediaCollection, Movie, MusicVideo};
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -126,8 +126,24 @@ impl SingleFormat {
 
     pub async fn stream(&self) -> Result<Stream> {
         let stream = match &self.source {
-            MediaCollection::Episode(e) => e.streams().await?,
-            MediaCollection::Movie(m) => m.streams().await?,
+            MediaCollection::Episode(e) => {
+                if let Ok(stream) = e.legacy_streams().await {
+                    stream
+                } else {
+                    let stream = e.streams().await?;
+                    warn!("Failed to get stream via legacy endpoint");
+                    stream
+                }
+            }
+            MediaCollection::Movie(m) => {
+                if let Ok(stream) = m.legacy_streams().await {
+                    stream
+                } else {
+                    let stream = m.streams().await?;
+                    warn!("Failed to get stream via legacy endpoint");
+                    stream
+                }
+            }
             MediaCollection::MusicVideo(mv) => mv.streams().await?,
             MediaCollection::Concert(c) => c.streams().await?,
             _ => unreachable!(),


### PR DESCRIPTION
This PR fixes the rate limiting error (`content.get_video_streams_v2.cms_service_error`) which occurs if many streams are requested in a short time period (#180). This fix only works for episodes and movies. If you download music videos or concerts this error can still occur. But based on tests you'd have to download 40-50 music videos/concerts to trigger the rate limit.