### PR TITLE
Fix default value for locale arg overwriting audio arg

### DIFF
--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -31,7 +31,7 @@ pub struct Archive {
     #[arg(short, long, default_values_t = vec![Locale::ja_JP, crate::utils::locale::system_locale()])]
     pub(crate) audio: Vec<Locale>,
     #[arg(help = "Deprecated. Use '-a' / '--audio' instead")]
-    #[arg(short, long, default_values_t = Vec::<Locale>::new())]
+    #[arg(short, long)]
     locale: Vec<Locale>,
     #[arg(help = format!("Subtitle languages. Can be used multiple times. \
     Available languages are: {}", Locale::all().into_iter().map(|l| l.to_string()).collect::<Vec<String>>().join(", ")))]

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -31,7 +31,7 @@ pub struct Archive {
     #[arg(short, long, default_values_t = vec![Locale::ja_JP, crate::utils::locale::system_locale()])]
     pub(crate) audio: Vec<Locale>,
     #[arg(help = "Deprecated. Use '-a' / '--audio' instead")]
-    #[arg(short, long, default_values_t = vec![Locale::ja_JP, crate::utils::locale::system_locale()])]
+    #[arg(short, long, default_values_t = Vec::<Locale>::new())]
     locale: Vec<Locale>,
     #[arg(help = format!("Subtitle languages. Can be used multiple times. \
     Available languages are: {}", Locale::all().into_iter().map(|l| l.to_string()).collect::<Vec<String>>().join(", ")))]


### PR DESCRIPTION
Just recently pulled the changes from https://github.com/crunchy-labs/crunchy-cli/commit/f584c8028fb9d9b2f05359ccb03cc33f7373c9de, but it looks like you left in the default values in for locales. 

Even when audio arg is specified, it tacks on system locale.
```
$ crunchy-cli archive <URL> -a ja-JP -s en-US
:: The '-l' / '--locale' flag is deprecated, use '-a' / '--audio' instead
...
:: 	Episode: S02E11
:: 	Audio: ja-JP, en-US
:: 	Subtitles: en-US
:: 	Resolution: 1920x1080
:: 	FPS: 23.97
```

Not actually sure how clap works, but I assume it initializes an empty vec when you leave it out. Didn't seem to break it.