### PR TITLE
Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-/.idea
+# Rust
 /target
+
+# Editor
+/.idea
 /.vscode
+
+# Nix
+/result
+/.direnv

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ A pure [Rust](https://www.rust-lang.org/) CLI for [Crunchyroll](https://www.crun
 
 Check out the [releases](https://github.com/crunchy-labs/crunchy-cli/releases) tab and get the binary from the latest (pre-)release.
 
+### ❄️  The nix way
+
+This requires [nix](https://nixos.org) and you'll probably need `--extra-experimental-features "nix-command flakes"` depending on your configurations.
+```shell
+$ nix <run|shell|develop> github:crunchy-labs/crunchy-cli
+```
+
 ### 🛠 Build it yourself
 
 Since we do not support every platform and architecture you may have to build the project yourself.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685866647,
+        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,78 @@
+{
+  inputs = {
+    nixpkgs.url = "flake:nixpkgs/nixpkgs-unstable";
+    utils.url = "flake:flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, ... }: utils.lib.eachSystem [
+    "aarch64-darwin"
+    "x86_64-darwin"
+    "aarch64-linux"
+    "x86_64-linux"
+  ]
+    (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        # enable musl on Linux makes the build time 100x slower
+        # since it will trigger a toolchain rebuild
+        # if nixpkgs.legacyPackages.${system}.stdenv.hostPlatform.isLinux
+        # then nixpkgs.legacyPackages.${system}.pkgsMusl
+        # else nixpkgs.legacyPackages.${system};
+
+        crunchy-cli = pkgs.rustPlatform.buildRustPackage.override { stdenv = pkgs.clangStdenv; } rec {
+          pname = "crunchy-cli";
+          inherit ((pkgs.lib.importTOML ./Cargo.toml).package) version;
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            allowBuiltinFetchGit = true;
+          };
+
+          nativeBuildInputs = [
+            pkgs.pkg-config
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.xcbuild
+          ];
+
+          buildInputs = [
+            pkgs.openssl
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.Security
+          ];
+        };
+      in
+      {
+        packages.default = crunchy-cli;
+
+        overlays.default = _: prev: {
+          crunchy-cli = prev.crunchy-cli.override { };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cargo
+            clippy
+            rust-analyzer
+            rustc
+            rustfmt
+          ];
+
+          inputsFrom = builtins.attrValues self.packages.${system};
+
+          buildInputs = [
+            pkgs.openssl
+            pkgs.libiconv
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.CoreServices
+            pkgs.darwin.Security
+          ];
+
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}


### PR DESCRIPTION
Hi crunchy-cli authors/maintainers, thanks for building this amazing project!

This PR:

- add following functionality:
  - nix develop with direnv support
  - nix run and nix shell
  - nix fmt for flake.nix
  - and package overlay for https://github.com/NixOS/nixpkgs/pull/225502
- resources used
  - https://stackoverflow.com/questions/53272197/how-do-i-override-the-libc-in-a-nix-package-to-be-musl
  - https://github.com/NixOS/nixpkgs/blob/dd3aca2d0b9dcb4888779bfb08805d79596607c9/pkgs/top-level/stage.nix#L136
- inspired by https://github.com/typst/typst/blob/main/flake.nix

Tested on aarch64-darwin and x86_64-linux.

Some questions:

1. Do I need to add documentation for this to README.md or anywhere else?
2. It is possible to cache the build outputs ([Binary Cache](https://nixos.wiki/wiki/Binary_Cache)) to [Cachix](https://www.cachix.org/), but it requires some changes to GitHub Action workflow and setting up an account with Cachix. Is this something that's necessary?

Thanks again!