### PR TITLE
Add release ci pipeline

### DIFF
--- a/.github/scripts/PKGBUILD.binary
+++ b/.github/scripts/PKGBUILD.binary
@@ -1,0 +1,39 @@
+# Maintainer: ByteDream
+pkgname=crunchy-cli-bin
+pkgdesc="Command-line downloader for Crunchyroll"
+arch=('x86_64')
+url="https://github.com/crunchy-labs/crunchy-cli"
+license=('MIT')
+
+pkgver=$CI_PKG_VERSION
+pkgrel=1
+
+depends=('ffmpeg')
+source=(
+  "crunchy-cli::https://github.com/crunchy-labs/crunchy-cli/releases/download/v${pkgver}/crunchy-cli-v${pkgver}-linux-x86_64"
+  "manpages.zip::https://github.com/crunchy-labs/crunchy-cli/releases/download/v${pkgver}/crunchy-cli-v${pkgver}-manpages.zip"
+  "completions.zip::https://github.com/crunchy-labs/crunchy-cli/releases/download/v${pkgver}/crunchy-cli-v${pkgver}-completions.zip"
+  "LICENSE::https://raw.githubusercontent.com/crunchy-labs/crunchy-cli/v${pkgver}/LICENSE"
+)
+noextract=("manpages.zip" "completions.zip")
+sha256sums=('$CI_SHA_SUM' '$CI_MANPAGES_SHA_SUM' '$CI_COMPLETIONS_SHA_SUM' '$CI_LICENSE_SHA_SUM')
+
+package() {
+  cd "$srcdir"
+
+  # all files in manpages.zip and completions.zip are stored in root of the archive, makepkg extracts them all to $srcdir
+  # which makes it pretty messy. so the extraction is done manually to keep the content of $srcdir structured
+  mkdir manpages completions
+  cd manpages
+  bsdtar -xf ../manpages.zip
+  cd ../completions
+  bsdtar -xf ../completions.zip
+  cd ..
+
+  install -Dm755 crunchy-cli $pkgdir/usr/bin/crunchy-cli
+  install -Dm644 manpages/* -t $pkgdir/usr/share/man/man1
+  install -Dm644 completions/crunchy-cli.bash $pkgdir/usr/share/bash-completions/completions/crunchy-cli
+  install -Dm644 completions/_crunchy-cli $pkgdir/usr/share/zsh/site-functions/_crunchy-cli
+  install -Dm644 completions/crunchy-cli.fish $pkgdir/usr/share/fish/vendor_completions.d/crunchy-cli.fish
+  install -Dm644 LICENSE $pkgdir/usr/share/licenses/crunchy-cli/LICENSE
+}

--- a/.github/scripts/PKGBUILD.source
+++ b/.github/scripts/PKGBUILD.source
@@ -1,0 +1,34 @@
+# Maintainer: ByteDream
+pkgname=crunchy-cli
+pkgdesc="Command-line downloader for Crunchyroll"
+arch=('x86_64' 'i686' 'arm' 'armv6h' 'armv7h' 'aarch64')
+url="https://github.com/crunchy-labs/crunchy-cli"
+license=('MIT')
+
+pkgver=$CI_PKG_VERSION
+pkgrel=1
+
+depends=('ffmpeg' 'openssl')
+makedepends=('cargo')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/crunchy-labs/crunchy-cli/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('$CI_SHA_SUM')
+
+build() {
+  cd "$srcdir/${pkgname}-$pkgver"
+
+  export CARGO_HOME="$srcdir/cargo-home"
+  export RUSTUP_TOOLCHAIN=stable
+
+  cargo build --release --no-default-features --features openssl
+}
+
+package() {
+  cd "$srcdir/${pkgname}-$pkgver"
+
+  install -Dm755 target/release/crunchy-cli $pkgdir/usr/bin/crunchy-cli
+  install -Dm644 target/release/manpages/* $pkgdir/usr/share/man/man1
+  install -Dm644 target/release/completions/crunchy-cli.bash $pkgdir/usr/share/bash-completions/completions/crunchy-cli
+  install -Dm644 target/release/completions/_crunchy-cli $pkgdir/usr/share/zsh/site-functions/_crunchy-cli
+  install -Dm644 target/release/completions/crunchy-cli.fish $pkgdir/usr/share/fish/vendor_completions.d/crunchy-cli.fish
+  install -Dm644 LICENSE $pkgdir/usr/share/licenses/crunchy-cli/LICENSE
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish-aur:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get version
+        run: echo "RELEASE_VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)" >> $GITHUB_ENV
+
+      - name: Generate crunchy-cli sha sum
+        run: |
+          curl -LO https://github.com/crunchy-labs/crunchy-cli/archive/refs/tags/${{ github.ref_name }}.tar.gz
+          echo "CRUNCHY_CLI_SHA256=$(sha256sum ${{ github.ref_name }}.tar.gz | cut -f 1 -d ' ')" >> $GITHUB_ENV
+
+      - name: Generate crunchy-cli PKGBUILD
+        env:
+          CI_PKG_VERSION: ${{ env.RELEASE_VERSION }}
+          CI_SHA_SUM: ${{ env.CRUNCHY_CLI_SHA256 }}
+        run: envsubst '$CI_PKG_VERSION,$CI_SHA_SUM' < .github/scripts/PKGBUILD.source > PKGBUILD
+
+      - name: Publish crunchy-cli to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@2.7.0
+        with:
+          pkgname: crunchy-cli
+          pkgbuild: ./PKGBUILD
+          commit_username: release-action
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to version {{ env.RELEASE_VERSION }}
+          test: true
+
+      - name: Generate crunchy-cli-bin sha sums
+        run: |
+          curl -LO https://github.com/crunchy-labs/crunchy-cli/releases/download/${{ github.ref_name }}/crunchy-cli-${{ github.ref_name }}-x86_64-linux
+          curl -LO https://github.com/crunchy-labs/crunchy-cli/releases/download/${{ github.ref_name }}/crunchy-cli-${{ github.ref_name }}-completions.zip
+          curl -LO https://github.com/crunchy-labs/crunchy-cli/releases/download/${{ github.ref_name }}/crunchy-cli-${{ github.ref_name }}-manpages.zip
+          curl -LO https://raw.githubusercontent.com/crunchy-labs/crunchy-cli/${{ github.ref_name }}/LICENSE
+          echo "CRUNCHY_CLI_BIN_SHA256=$(sha256sum crunchy-cli-${{ github.ref_name }}-x86_64-linux | cut -f 1 -d ' ')" >> $GITHUB_ENV
+          echo "CRUNCHY_CLI_BIN_COMPLETIONS_SHA256=$(sha256sum crunchy-cli-${{ github.ref_name }}-completions.zip | cut -f 1 -d ' ')" >> $GITHUB_ENV
+          echo "CRUNCHY_CLI_BIN_MANPAGES_SHA256=$(sha256sum crunchy-cli-${{ github.ref_name }}-manpages.zip | cut -f 1 -d ' ')" >> $GITHUB_ENV
+          echo "CRUNCHY_CLI_BIN_LICENSE_SHA256=$(sha256sum LICENSE | cut -f 1 -d ' ')" >> $GITHUB_ENV
+
+      - name: Generate crunchy-cli-bin PKGBUILD
+        env:
+          CI_PKG_VERSION: ${{ env.RELEASE_VERSION }}
+          CI_SHA_SUM: ${{ env.CRUNCHY_CLI_BIN_SHA256 }}
+          CI_MANPAGES_SHA_SUM: ${{ env.CRUNCHY_CLI_BIN_MANPAGES_SHA256 }}
+          CI_COMPLETIONS_SHA_SUM: ${{ env.CRUNCHY_CLI_BIN_COMPLETIONS_SHA256 }}
+          CI_LICENSE_SHA_SUM: ${{ env.CRUNCHY_CLI_BIN_LICENSE_SHA256 }}
+        run: envsubst '$CI_PKG_VERSION,$CI_SHA_SUM,$CI_COMPLETIONS_SHA_SUM,$CI_MANPAGES_SHA_SUM' < .github/scripts/PKGBUILD.binary > PKGBUILD
+
+      - name: Publish crunchy-cli-bin to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@2.7.0
+        with:
+          pkgname: crunchy-cli-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: release-action
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: Update to version {{ env.RELEASE_VERSION }}
+          test: true


### PR DESCRIPTION
This PR adds a pipeline which is triggered whenever a new release is made. ATM its only purpose is to publish the [AUR](https://aur.archlinux.org/) `crunchy-cli` and upcoming `crunchy-cli-bin` package.