### PR TITLE
Fix nix flake overlays

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
When I was looking at https://github.com/crunchy-labs/crunchy-cli/issues/235, I found a mistake I made when first making the flake:

```shell
$ nix flake check --all-systems .
error (ignored): error:
       … while checking the overlay 'overlays.aarch64-darwin'

         at /nix/store/xkci0s3glinkrb3prpz0ah6b8fg51504-source/lib.nix:69:24:

           68|                 then (pushDownSystem system (attrs.hydraJobs or { }) ret.hydraJobs)
           69|                 else { ${system} = ret.${key}; };
             |                        ^
           70|             in

       error: overlay is not a function, but a set instead
error (ignored): error:
       … while checking the overlay 'overlays.x86_64-darwin'

         at /nix/store/xkci0s3glinkrb3prpz0ah6b8fg51504-source/lib.nix:69:24:

           68|                 then (pushDownSystem system (attrs.hydraJobs or { }) ret.hydraJobs)
           69|                 else { ${system} = ret.${key}; };
             |                        ^
           70|             in

       error: overlay is not a function, but a set instead
error (ignored): error:
       … while checking the overlay 'overlays.aarch64-linux'

         at /nix/store/xkci0s3glinkrb3prpz0ah6b8fg51504-source/lib.nix:69:24:

           68|                 then (pushDownSystem system (attrs.hydraJobs or { }) ret.hydraJobs)
           69|                 else { ${system} = ret.${key}; };
             |                        ^
           70|             in

       error: overlay is not a function, but a set instead
error (ignored): error:
       … while checking the overlay 'overlays.x86_64-linux'

         at /nix/store/xkci0s3glinkrb3prpz0ah6b8fg51504-source/lib.nix:69:24:

           68|                 then (pushDownSystem system (attrs.hydraJobs or { }) ret.hydraJobs)
           69|                 else { ${system} = ret.${key}; };
             |                        ^
           70|             in

       error: overlay is not a function, but a set instead
error: some errors were encountered during the evaluation
```

`overlays` attrset should be put outside of `eachDefaultSystem`, this PR fixes it and also updated the lock file. Tested basic functionality on aarch64-darwin.