### PR TITLE
Add FFmpeg Apple hardware acceleration and make HEVC codec compatible with Apple standards

### DIFF
--- a/crunchy-cli-core/src/utils/ffmpeg.rs
+++ b/crunchy-cli-core/src/utils/ffmpeg.rs
@@ -66,7 +66,8 @@ ffmpeg_enum! {
 
 ffmpeg_enum! {
     enum FFmpegHwAccel {
-        Nvidia
+        Nvidia,
+        Apple
     }
 }
 
@@ -275,6 +276,9 @@ impl FFmpegPreset {
                                     ]);
                                     output.extend(["-c:v", "h264_nvenc", "-c:a", "copy"])
                                 }
+                                FFmpegHwAccel::Apple => {
+                                    output.extend(["-c:v", "h264_videotoolbox", "-c:a", "copy"])
+                                }
                             }
                         } else {
                             output.extend(["-c:v", "libx264", "-c:a", "copy"])
@@ -299,6 +303,9 @@ impl FFmpegPreset {
                                         "h264_cuvid",
                                     ]);
                                     output.extend(["-c:v", "hevc_nvenc", "-c:a", "copy"])
+                                }
+                                FFmpegHwAccel::Apple => {
+                                    output.extend(["-c:v", "hevc_videotoolbox", "-c:a", "copy"])
                                 }
                             }
                         } else {

--- a/crunchy-cli-core/src/utils/ffmpeg.rs
+++ b/crunchy-cli-core/src/utils/ffmpeg.rs
@@ -302,14 +302,26 @@ impl FFmpegPreset {
                                         "-c:v",
                                         "h264_cuvid",
                                     ]);
-                                    output.extend(["-c:v", "hevc_nvenc", "-c:a", "copy"])
+                                    output.extend([
+                                        "-c:v",
+                                        "hevc_nvenc",
+                                        "-c:a",
+                                        "copy",
+                                        "-tag:v",
+                                        "hvc1",
+                                    ])
                                 }
-                                FFmpegHwAccel::Apple => {
-                                    output.extend(["-c:v", "hevc_videotoolbox", "-c:a", "copy"])
-                                }
+                                FFmpegHwAccel::Apple => output.extend([
+                                    "-c:v",
+                                    "hevc_videotoolbox",
+                                    "-c:a",
+                                    "copy",
+                                    "-tag:v",
+                                    "hvc1",
+                                ]),
                             }
                         } else {
-                            output.extend(["-c:v", "libx265", "-c:a", "copy"])
+                            output.extend(["-c:v", "libx265", "-c:a", "copy", "-tag:v", "hvc1"])
                         }
 
                         match quality {


### PR DESCRIPTION
This pull request adds an `Apple` variant to `FFmpegHwAccel`, which uses Video Toolbox encoders where available (`h264_videotoolbox` and `hevc_videotoolbox`). The Video Toolbox encoders are significantly more performant on Apple devices, such as Macs. These encoders do not accept the `-crf` option, however, they instead accept `-q:v`. The code setting quality options has been adjusted to allow for hardware acceleration dependence.

This pull request also makes videos encoded in HEVC actually work on Apple devices by adding the `hvc1` tag, since I didn't want to create a whole other pull request and I couldn't actually test the other changes in this PR without fixing this.