### PR TITLE
Fix `ffmpeg-preset` option in `download` command

### DIFF
--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -148,7 +148,8 @@ impl Execute for Download {
                     Some("mpegts".to_string())
                 } else {
                     None
-                });
+                })
+                .ffmpeg_preset(self.ffmpeg_preset.clone().unwrap_or_default());
 
             for mut single_formats in single_format_collection.into_iter() {
                 // the vec contains always only one item


### PR DESCRIPTION
I noticed that although the `download` command has an `ffmpeg-preset` option, it doesn't actually do anything with its value. This pull request fixes this.