### PR TITLE
Add `--threads` (`-t`) option to downloading commands

### DIFF
--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -98,6 +98,10 @@ pub struct Archive {
     #[arg(short, long, default_value_t = false)]
     pub(crate) yes: bool,
 
+    #[arg(help = "Download using only one thread")]
+    #[arg(short = 't', long, default_value_t = false)]
+    pub(crate) single_threaded: bool,
+
     #[arg(help = "Crunchyroll series url(s)")]
     #[arg(required = true)]
     pub(crate) urls: Vec<String>,
@@ -158,7 +162,8 @@ impl Execute for Archive {
                 .ffmpeg_preset(self.ffmpeg_preset.clone().unwrap_or_default())
                 .output_format(Some("matroska".to_string()))
                 .audio_sort(Some(self.audio.clone()))
-                .subtitle_sort(Some(self.subtitle.clone()));
+                .subtitle_sort(Some(self.subtitle.clone()))
+                .single_threaded(self.single_threaded);
 
             for single_formats in single_format_collection.into_iter() {
                 let (download_formats, mut format) = get_format(&self, &single_formats).await?;

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -98,9 +98,9 @@ pub struct Archive {
     #[arg(short, long, default_value_t = false)]
     pub(crate) yes: bool,
 
-    #[arg(help = "Download using only one thread")]
-    #[arg(short = 't', long, default_value_t = false)]
-    pub(crate) single_threaded: bool,
+    #[arg(help = "Override the number of threads used to download")]
+    #[arg(short, long)]
+    pub(crate) threads: Option<usize>,
 
     #[arg(help = "Crunchyroll series url(s)")]
     #[arg(required = true)]
@@ -163,7 +163,7 @@ impl Execute for Archive {
                 .output_format(Some("matroska".to_string()))
                 .audio_sort(Some(self.audio.clone()))
                 .subtitle_sort(Some(self.subtitle.clone()))
-                .single_threaded(self.single_threaded);
+                .threads(self.threads);
 
             for single_formats in single_format_collection.into_iter() {
                 let (download_formats, mut format) = get_format(&self, &single_formats).await?;

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -98,9 +98,9 @@ pub struct Archive {
     #[arg(short, long, default_value_t = false)]
     pub(crate) yes: bool,
 
-    #[arg(help = "Override the number of threads used to download")]
-    #[arg(short, long)]
-    pub(crate) threads: Option<usize>,
+    #[arg(help = "The number of threads used to download")]
+    #[arg(short, long, default_value_t = num_cpus::get())]
+    pub(crate) threads: usize,
 
     #[arg(help = "Crunchyroll series url(s)")]
     #[arg(required = true)]

--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -80,9 +80,9 @@ pub struct Download {
     #[arg(long, default_value_t = false)]
     pub(crate) force_hardsub: bool,
 
-    #[arg(help = "Override the number of threads used to download")]
-    #[arg(short, long)]
-    pub(crate) threads: Option<usize>,
+    #[arg(help = "The number of threads used to download")]
+    #[arg(short, long, default_value_t = num_cpus::get())]
+    pub(crate) threads: usize,
 
     #[arg(help = "Url(s) to Crunchyroll episodes or series")]
     #[arg(required = true)]

--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -80,9 +80,9 @@ pub struct Download {
     #[arg(long, default_value_t = false)]
     pub(crate) force_hardsub: bool,
 
-    #[arg(help = "Download using only one thread")]
-    #[arg(short = 't', long, default_value_t = false)]
-    pub(crate) single_threaded: bool,
+    #[arg(help = "Override the number of threads used to download")]
+    #[arg(short, long)]
+    pub(crate) threads: Option<usize>,
 
     #[arg(help = "Url(s) to Crunchyroll episodes or series")]
     #[arg(required = true)]
@@ -154,7 +154,7 @@ impl Execute for Download {
                     None
                 })
                 .ffmpeg_preset(self.ffmpeg_preset.clone().unwrap_or_default())
-                .single_threaded(self.single_threaded);
+                .threads(self.threads);
 
             for mut single_formats in single_format_collection.into_iter() {
                 // the vec contains always only one item

--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -80,6 +80,10 @@ pub struct Download {
     #[arg(long, default_value_t = false)]
     pub(crate) force_hardsub: bool,
 
+    #[arg(help = "Download using only one thread")]
+    #[arg(short = 't', long, default_value_t = false)]
+    pub(crate) single_threaded: bool,
+
     #[arg(help = "Url(s) to Crunchyroll episodes or series")]
     #[arg(required = true)]
     pub(crate) urls: Vec<String>,
@@ -149,7 +153,8 @@ impl Execute for Download {
                 } else {
                     None
                 })
-                .ffmpeg_preset(self.ffmpeg_preset.clone().unwrap_or_default());
+                .ffmpeg_preset(self.ffmpeg_preset.clone().unwrap_or_default())
+                .single_threaded(self.single_threaded);
 
             for mut single_formats in single_format_collection.into_iter() {
                 // the vec contains always only one item

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -50,7 +50,7 @@ pub struct DownloadBuilder {
     audio_sort: Option<Vec<Locale>>,
     subtitle_sort: Option<Vec<Locale>>,
     force_hardsub: bool,
-    threads: Option<usize>,
+    threads: usize,
 }
 
 impl DownloadBuilder {
@@ -62,7 +62,7 @@ impl DownloadBuilder {
             audio_sort: None,
             subtitle_sort: None,
             force_hardsub: false,
-            threads: None,
+            threads: num_cpus::get(),
         }
     }
 
@@ -102,7 +102,7 @@ pub struct Downloader {
     subtitle_sort: Option<Vec<Locale>>,
 
     force_hardsub: bool,
-    threads: Option<usize>,
+    threads: usize,
 
     formats: Vec<DownloadFormat>,
 }
@@ -575,8 +575,7 @@ impl Downloader {
             None
         };
 
-        // If `threads` is specified, use that many CPU cores(?).
-        let cpus = self.threads.unwrap_or(num_cpus::get());
+        let cpus = self.threads;
         let mut segs: Vec<Vec<VariantSegment>> = Vec::with_capacity(cpus);
         for _ in 0..cpus {
             segs.push(vec![])

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -576,11 +576,7 @@ impl Downloader {
         };
 
         // If `threads` is specified, use that many CPU cores(?).
-        let cpus = if let Some(threads) = self.threads {
-            threads
-        } else {
-            num_cpus::get()
-        };
+        let cpus = self.threads.unwrap_or(num_cpus::get());
         let mut segs: Vec<Vec<VariantSegment>> = Vec::with_capacity(cpus);
         for _ in 0..cpus {
             segs.push(vec![])

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -50,7 +50,7 @@ pub struct DownloadBuilder {
     audio_sort: Option<Vec<Locale>>,
     subtitle_sort: Option<Vec<Locale>>,
     force_hardsub: bool,
-    single_threaded: bool,
+    threads: Option<usize>,
 }
 
 impl DownloadBuilder {
@@ -62,7 +62,7 @@ impl DownloadBuilder {
             audio_sort: None,
             subtitle_sort: None,
             force_hardsub: false,
-            single_threaded: false,
+            threads: None,
         }
     }
 
@@ -75,7 +75,7 @@ impl DownloadBuilder {
             subtitle_sort: self.subtitle_sort,
 
             force_hardsub: self.force_hardsub,
-            single_threaded: self.single_threaded,
+            threads: self.threads,
 
             formats: vec![],
         }
@@ -102,7 +102,7 @@ pub struct Downloader {
     subtitle_sort: Option<Vec<Locale>>,
 
     force_hardsub: bool,
-    single_threaded: bool,
+    threads: Option<usize>,
 
     formats: Vec<DownloadFormat>,
 }
@@ -575,9 +575,9 @@ impl Downloader {
             None
         };
 
-        // Only use 1 CPU (core?) if `single-threaded` option is enabled
-        let cpus = if self.single_threaded {
-            1
+        // If `threads` is specified, use that many CPU cores(?).
+        let cpus = if let Some(threads) = self.threads {
+            threads
         } else {
             num_cpus::get()
         };


### PR DESCRIPTION
This PR adds a `threads` field to `DownloadBuilder` and `Downloader` and adds a `--threads` (or `-t` for short) option to the `download` and `archive` commands. This overrides the cores that `Downloader` utilizes for downloading. This is useful in situations such as my own where having one program utilize all cores for downloading renders the rest of the device practically unusable. I understand that the name `--threads` might not be entirely accurate as to what it does since I think the number of threads `tokio` uses is the same to some extent even with this new option, so I'm open to suggestions for a more accurate name.