### PR TITLE
add minimum subtitle size

### DIFF
--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -114,6 +114,12 @@ pub struct Archive {
     #[arg(long)]
     pub(crate) include_fonts: bool,
 
+    #[arg(
+        help = "If a subtitle byte size is less than this amount, it is not included in the downloaded file."
+    )]
+    #[arg(long, default_value_t = 0)]
+    pub(crate) meaningful_subtitle_size: u64,
+
     #[arg(help = "Skip files which are already existing")]
     #[arg(long, default_value_t = false)]
     pub(crate) skip_existing: bool,
@@ -213,6 +219,7 @@ impl Execute for Archive {
                     .output_format(Some("matroska".to_string()))
                     .audio_sort(Some(self.audio.clone()))
                     .subtitle_sort(Some(self.subtitle.clone()))
+                    .meaningful_subtitle_min_size(self.meaningful_subtitle_size)
                     .threads(self.threads);
 
             for single_formats in single_format_collection.into_iter() {

--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -104,6 +104,12 @@ pub struct Download {
     #[arg(long, default_value_t = false)]
     pub(crate) force_hardsub: bool,
 
+    #[arg(
+        help = "If a subtitle byte size is less than this amount, it is not included in the downloaded file."
+    )]
+    #[arg(long, default_value_t = 0)]
+    pub(crate) meaningful_subtitle_size: u64,
+
     #[arg(help = "The number of threads used to download")]
     #[arg(short, long, default_value_t = num_cpus::get())]
     pub(crate) threads: usize,
@@ -220,6 +226,7 @@ impl Execute for Download {
                 DownloadBuilder::new(ctx.client.clone(), ctx.rate_limiter.clone())
                     .default_subtitle(self.subtitle.clone())
                     .force_hardsub(self.force_hardsub)
+                    .meaningful_subtitle_min_size(self.meaningful_subtitle_size)
                     .output_format(if is_special_file(&self.output) || self.output == "-" {
                         Some("mpegts".to_string())
                     } else {


### PR DESCRIPTION
Dubbed videos have subtitles but they often have no useful information and can clutter download files. This PR adds a parameter to set a minimum meaningful subtitle file size (defaulting to 0, though I've found 4K works well even for short videos).