### PR TITLE
Add archive `--skip-existing-method` flag (#292)

### DIFF
--- a/crunchy-cli-core/src/download/command.rs
+++ b/crunchy-cli-core/src/download/command.rs
@@ -94,7 +94,7 @@ pub struct Download {
     #[arg(long)]
     pub(crate) ffmpeg_threads: Option<usize>,
 
-    #[arg(help = "Skip files which are already existing")]
+    #[arg(help = "Skip files which are already existing by their name")]
     #[arg(long, default_value_t = false)]
     pub(crate) skip_existing: bool,
     #[arg(help = "Skip special episodes")]
@@ -259,7 +259,7 @@ impl Execute for Download {
                         self.output_specials
                             .as_ref()
                             .map_or((&self.output).into(), |so| so.into()),
-                            self.universal_output,
+                        self.universal_output,
                     )
                 } else {
                     format.format_path((&self.output).into(), self.universal_output)


### PR DESCRIPTION
This PR adds the `--skip-existing-method` flag to `archive`.

By default, when specifying `--skip-existing` and downloading an episode and the file to which the episode gets downloaded already exists, the download of this episode is skipped. But in some cases this is not the desired behavior, e.g. when an audio or subtitle language got added. To make this a bit more flexible, the `--skip-existing-method` is added. It can take `audio` and/or `subtitle` as argument. If given, it checks if the already downloaded file (is a video and) has different audio/subtitle languages than the one you want to download. If this is the case, the episode will be downloaded instead of being skipped and replaces the already existing file.