### PR TITLE
move format_time_delta to own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,13 +471,13 @@ The `archive` command lets you download episodes with multiple audios and subtit
 
   Default is `auto`.
 
-- <span id="archive-merge-auto-tolerance">Merge auto tolerance</span>
+- <span id="archive-merge-time-tolerance">Merge time tolerance</span>
 
   Sometimes two video tracks are downloaded with `--merge` set to `auto` even if they only differ some milliseconds in length which shouldn't be noticeable to the viewer.
-  To prevent this, you can specify a range in milliseconds with the `--merge-auto-tolerance` flag that only downloads one video if the length difference is in the given range.
+  To prevent this, you can specify a range in milliseconds with the `--merge-time-tolerance` flag that only downloads one video if the length difference is in the given range.
 
   ```shell
-  $ crunchy-cli archive -m auto --merge-auto-tolerance 100 https://www.crunchyroll.com/series/GY8VEQ95Y/darling-in-the-franxx
+  $ crunchy-cli archive -m auto --merge-time-tolerance 100 https://www.crunchyroll.com/series/GY8VEQ95Y/darling-in-the-franxx
   ```
   
   Default are `200` milliseconds.

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -104,7 +104,7 @@ pub struct Archive {
         help = "If the merge behavior is 'auto', only download multiple video tracks if their length difference is higher than the given milliseconds"
     )]
     #[arg(long, default_value_t = 200)]
-    pub(crate) merge_auto_tolerance: u32,
+    pub(crate) merge_time_tolerance: u32,
     #[arg(help = "Tries to sync the timing of all downloaded audios to match one video")]
     #[arg(
         long_help = "Tries to sync the timing of all downloaded audios to match one video. \
@@ -577,7 +577,7 @@ async fn get_format(
                             .sub(single_format.duration)
                             .abs()
                             .num_milliseconds()
-                            < archive.merge_auto_tolerance.into() =>
+                            < archive.merge_time_tolerance.into() =>
                     {
                         // If less than `audio_error` apart, use same audio.
                         closest_format

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -1,5 +1,6 @@
 use crate::utils::ffmpeg::FFmpegPreset;
 use crate::utils::filter::real_dedup_vec;
+use crate::utils::fmt::format_time_delta;
 use crate::utils::log::progress;
 use crate::utils::os::{
     cache_dir, is_special_file, temp_directory, temp_named_pipe, tempdir, tempfile,
@@ -595,7 +596,7 @@ impl Downloader {
 
         for (i, meta) in videos.iter().enumerate() {
             if let Some(start_time) = meta.start_time {
-                input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                input.extend(["-ss".to_string(), format_time_delta(&start_time)])
             }
             input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
             maps.extend(["-map".to_string(), i.to_string()]);
@@ -616,7 +617,7 @@ impl Downloader {
         }
         for (i, meta) in audios.iter().enumerate() {
             if let Some(start_time) = meta.start_time {
-                input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                input.extend(["-ss".to_string(), format_time_delta(&start_time)])
             }
             input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
             maps.extend(["-map".to_string(), (i + videos.len()).to_string()]);
@@ -663,7 +664,7 @@ impl Downloader {
         if container_supports_softsubs {
             for (i, meta) in subtitles.iter().enumerate() {
                 if let Some(start_time) = meta.start_time {
-                    input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                    input.extend(["-ss".to_string(), format_time_delta(&start_time)])
                 }
                 input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
                 maps.extend([
@@ -1390,8 +1391,8 @@ fn fix_subtitles(raw: &mut Vec<u8>, max_length: TimeDelta) {
                         format!(
                             "Dialogue: {},{},{},",
                             layer,
-                            format_time_delta(start),
-                            format_time_delta(end)
+                            format_time_delta(&start),
+                            format_time_delta(&end)
                         ),
                     )
                     .to_string()
@@ -1663,18 +1664,6 @@ fn check_frame_windows(base_hashes: &[ImageHash], check_hashes: &[ImageHash]) ->
         results.push(sum as f64 / check_window.len() as f64);
     }
     results
-}
-
-fn format_time_delta(time_delta: TimeDelta) -> String {
-    let hours = time_delta.num_hours();
-    let minutes = time_delta.num_minutes() - time_delta.num_hours() * 60;
-    let seconds = time_delta.num_seconds() - time_delta.num_minutes() * 60;
-    let milliseconds = time_delta.num_milliseconds() - time_delta.num_seconds() * 1000;
-
-    format!(
-        "{}:{:0>2}:{:0>2}.{:0>3}",
-        hours, minutes, seconds, milliseconds
-    )
 }
 
 fn len_from_segments(segments: &[StreamSegment]) -> TimeDelta {

--- a/crunchy-cli-core/src/utils/fmt.rs
+++ b/crunchy-cli-core/src/utils/fmt.rs
@@ -1,0 +1,19 @@
+use chrono::TimeDelta;
+
+pub fn format_time_delta(time_delta: &TimeDelta) -> String {
+    let negative = *time_delta < TimeDelta::zero();
+    let time_delta = time_delta.abs();
+    let hours = time_delta.num_hours();
+    let minutes = time_delta.num_minutes() - time_delta.num_hours() * 60;
+    let seconds = time_delta.num_seconds() - time_delta.num_minutes() * 60;
+    let milliseconds = time_delta.num_milliseconds() - time_delta.num_seconds() * 1000;
+
+    format!(
+        "{}{}:{:0>2}:{:0>2}.{:0>3}",
+        if negative { "-" } else { "" },
+        hours,
+        minutes,
+        seconds,
+        milliseconds
+    )
+}

--- a/crunchy-cli-core/src/utils/mod.rs
+++ b/crunchy-cli-core/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod download;
 pub mod ffmpeg;
 pub mod filter;
+pub mod fmt;
 pub mod format;
 pub mod interactive_select;
 pub mod locale;


### PR DESCRIPTION
Move format_time_delta to its own file so that it can be called from another file in the future.

depends on #391 [Merged]