### PR TITLE
Switch to audio fingerprinting based syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,18 +180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "bytemuck"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,8 +369,6 @@ dependencies = [
  "fs2",
  "futures-util",
  "http",
- "image",
- "image_hasher",
  "indicatif",
  "lazy_static",
  "log",
@@ -391,6 +377,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls-native-certs",
+ "rusty-chromaprint",
  "serde",
  "serde_json",
  "serde_plain",
@@ -952,32 +939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
-dependencies = [
- "bytemuck",
- "byteorder",
- "num-traits",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "image_hasher"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481465fe767d92494987319b0b447a5829edf57f09c52bf8639396abaaeaf78"
-dependencies = [
- "base64 0.22.0",
- "image",
- "rustdct",
- "serde",
- "transpose",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953d9f7e5cdd80963547b456251296efc2626ed4e3cbf36c869d9564e0220571"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,19 +1502,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
+name = "rubato"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6dd52e80cfc21894deadf554a5673002938ae4625f7a283e536f9cf7c17b0d5"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "realfft",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustdct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
-dependencies = [
- "rustfft",
-]
 
 [[package]]
 name = "rustfft"
@@ -1626,6 +1599,16 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "rusty-chromaprint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1755646867c36ecb391776deaa0b557a76d3badf20c142de7282630c34b20440"
+dependencies = [
+ "rubato",
+ "rustfft",
 ]
 
 [[package]]
@@ -2501,18 +2484,3 @@ name = "zeroize"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
-
-[[package]]
-name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec866b44a2a1fd6133d363f073ca1b179f438f99e7e5bfb1e33f7181facfe448"
-dependencies = [
- "zune-core",
-]

--- a/README.md
+++ b/README.md
@@ -471,13 +471,13 @@ The `archive` command lets you download episodes with multiple audios and subtit
 
   Default is `auto`.
 
-- <span id="archive-merge-auto-tolerance">Merge auto tolerance</span>
+- <span id="archive-merge-time-tolerance">Merge time tolerance</span>
 
   Sometimes two video tracks are downloaded with `--merge` set to `auto` even if they only differ some milliseconds in length which shouldn't be noticeable to the viewer.
-  To prevent this, you can specify a range in milliseconds with the `--merge-auto-tolerance` flag that only downloads one video if the length difference is in the given range.
+  To prevent this, you can specify a range in milliseconds with the `--merge-time-tolerance` flag that only downloads one video if the length difference is in the given range.
 
   ```shell
-  $ crunchy-cli archive -m auto --merge-auto-tolerance 100 https://www.crunchyroll.com/series/GY8VEQ95Y/darling-in-the-franxx
+  $ crunchy-cli archive -m auto --merge-time-tolerance 100 https://www.crunchyroll.com/series/GY8VEQ95Y/darling-in-the-franxx
   ```
   
   Default are `200` milliseconds.

--- a/README.md
+++ b/README.md
@@ -485,9 +485,15 @@ The `archive` command lets you download episodes with multiple audios and subtit
 - <span id="archive-sync-tolerance">Sync tolerance</span>
 
   Sometimes two video tracks are downloaded with `--merge` set to `sync` because the audio fingerprinting fails to identify matching audio parts (e.g. opening).
-  To prevent this, you can use the "--sync-tolerance" flag to specify the difference by which two fingerprints are considered equal.
+  To prevent this, you can use the `--sync-tolerance` flag to specify the difference by which two fingerprints are considered equal.
 
   Default is `6`.
+
+- <span id="archive-sync-precision">Sync precision</span>
+
+  If you use `--merge` set to `sync` and the syncing seems to be not accurate enough or takes to long, you can use the `--sync-precision` flag to specify the amount of offset determination runs from which the final offset is calculated.
+
+  Default is `4`.
 
 - <span id="archive-language-tagging">Language tagging</span>
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ The `archive` command lets you download episodes with multiple audios and subtit
   In the best case, when multiple audio & subtitle tracks are used, there is only one *video* track and all other languages can be stored as audio-only.
   But, as said, this is not always the case.
   With the `-m` / `--merge` flag you can define the behaviour when an episodes' video tracks differ in length.
-  Valid options are `audio` - store one video and all other languages as audio only; `video` - store the video + audio for every language; `auto` - detect if videos differ in length: if so, behave like `video` - otherwise like `audio`.
+  Valid options are `audio` - store one video and all other languages as audio only; `video` - store the video + audio for every language; `auto` - detect if videos differ in length: if so, behave like `video` - otherwise like `audio`; `sync` - detect if videos differ in length: if so, it tries to find the offset of matching audio parts and removes the offset from the beginning, otherwise it behaves like `audio`.
   Subtitles will always match the primary audio and video.
 
   ```shell
@@ -482,15 +482,12 @@ The `archive` command lets you download episodes with multiple audios and subtit
   
   Default are `200` milliseconds.
 
-- <span id="archive-sync-start">Sync start</span>
+- <span id="archive-sync-tolerance">Sync tolerance</span>
 
-  If you want that all videos of the same episode should start at the same time and `--merge` doesn't fit your needs (e.g. one video has an intro, all other doesn't), you might consider using the `--sync-start`.
-  It tries to sync the timing of all downloaded audios to match one video.
-  This is done by downloading the first few segments/frames of all video tracks that differ in length and comparing them frame by frame.
-  The flag takes an optional value determines how accurate the syncing is, generally speaking everything over 15 begins to be more inaccurate and everything below 6 is too accurate (and won't succeed).
-  When the syncing fails, the command is continued as if `--sync-start` wasn't provided for this episode.
+  Sometimes two video tracks are downloaded with `--merge` set to `sync` because the audio fingerprinting fails to identify matching audio parts (e.g. opening).
+  To prevent this, you can use the "--sync-tolerance" flag to specify the difference by which two fingerprints are considered equal.
 
-  Default is `7.5`.
+  Default is `6`.
 
 - <span id="archive-language-tagging">Language tagging</span>
 

--- a/crunchy-cli-core/Cargo.toml
+++ b/crunchy-cli-core/Cargo.toml
@@ -24,14 +24,13 @@ derive_setters = "0.1"
 futures-util = { version = "0.3", features = ["io"] }
 fs2 = "0.4"
 http = "1.1"
-image = { version = "0.25", features = ["jpeg"], default-features = false }
-image_hasher = "2.0"
 indicatif = "0.17"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }
 num_cpus = "1.16"
 regex = "1.10"
 reqwest = { version = "0.12", features = ["socks", "stream"] }
+rusty-chromaprint = "0.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_plain = "1.0"

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -90,32 +90,31 @@ pub struct Archive {
     pub(crate) resolution: Resolution,
 
     #[arg(
-        help = "Sets the behavior of the stream merging. Valid behaviors are 'auto', 'audio' and 'video'"
+        help = "Sets the behavior of the stream merging. Valid behaviors are 'auto', 'sync', 'audio' and 'video'"
     )]
     #[arg(
         long_help = "Because of local restrictions (or other reasons) some episodes with different languages does not have the same length (e.g. when some scenes were cut out). \
     With this flag you can set the behavior when handling multiple language.
-    Valid options are 'audio' (stores one video and all other languages as audio only), 'video' (stores the video + audio for every language) and 'auto' (detects if videos differ in length: if so, behave like 'video' else like 'audio')"
+    Valid options are 'audio' (stores one video and all other languages as audio only), 'video' (stores the video + audio for every language), 'auto' (detects if videos differ in length: if so, behave like 'video' else like 'audio') and 'sync' (detects if videos differ in length: if so, tries to find the offset of matching audio parts and removes it from the beginning, otherwise it behaves like 'audio')"
     )]
     #[arg(short, long, default_value = "auto")]
     #[arg(value_parser = MergeBehavior::parse)]
     pub(crate) merge: MergeBehavior,
     #[arg(
-        help = "If the merge behavior is 'auto', only download multiple video tracks if their length difference is higher than the given milliseconds"
+        help = "If the merge behavior is 'auto' or 'sync', consider videos to be of equal lengths if the difference in length is smaller than the specified milliseconds"
     )]
     #[arg(long, default_value_t = 200)]
     pub(crate) merge_time_tolerance: u32,
-    #[arg(help = "Tries to sync the timing of all downloaded audios to match one video")]
     #[arg(
-        long_help = "Tries to sync the timing of all downloaded audios to match one video. \
-    This is done by downloading the first few segments/frames of all video tracks that differ in length and comparing them frame by frame. \
-    The value of this flag determines how accurate the syncing is, generally speaking everything over 15 begins to be more inaccurate and everything below 6 is too accurate (and won't succeed). \
-    If you want to provide a custom value to this flag, you have to set it with an equals (e.g. `--sync-start=10` instead of `--sync-start 10`). \
-    When the syncing fails, the command is continued as if `--sync-start` wasn't provided for this episode
-    "
+        help = "If the merge behavior is 'sync', specify the difference by which two fingerprints are considered equal"
     )]
-    #[arg(long, require_equals = true, num_args = 0..=1, default_missing_value = "7.5")]
-    pub(crate) sync_start: Option<f64>,
+    #[arg(long, default_value_t = 6)]
+    pub(crate) sync_tolerance: u32,
+    #[arg(
+        help = "If the merge behavior is 'sync', specify the amount of offset determination runs from which the final offset is calculated"
+    )]
+    #[arg(long, default_value_t = 4)]
+    pub(crate) sync_precision: u32,
 
     #[arg(
         help = "Specified which language tagging the audio and subtitle tracks and language specific format options should have. \
@@ -229,18 +228,10 @@ impl Execute for Archive {
         }
 
         if self.include_chapters
+            && !matches!(self.merge, MergeBehavior::Sync)
             && !matches!(self.merge, MergeBehavior::Audio)
-            && self.sync_start.is_none()
         {
-            bail!("`--include-chapters` can only be used if `--merge` is set to 'audio' or `--sync-start` is set")
-        }
-
-        if !matches!(self.merge, MergeBehavior::Auto) && self.sync_start.is_some() {
-            bail!("`--sync-start` can only be used if `--merge` is set to `auto`")
-        }
-
-        if self.sync_start.is_some() && self.ffmpeg_preset.is_none() {
-            warn!("Using `--sync-start` without `--ffmpeg-preset` might produce worse sync results than with `--ffmpeg-preset` set")
+            bail!("`--include-chapters` can only be used if `--merge` is set to 'audio' or 'sync'")
         }
 
         self.audio = all_locale_in_locales(self.audio.clone());
@@ -317,7 +308,14 @@ impl Execute for Archive {
                     .audio_sort(Some(self.audio.clone()))
                     .subtitle_sort(Some(self.subtitle.clone()))
                     .no_closed_caption(self.no_closed_caption)
-                    .sync_start_value(self.sync_start)
+                    .sync_tolerance(match self.merge {
+                        MergeBehavior::Sync => Some(self.sync_tolerance),
+                        _ => None,
+                    })
+                    .sync_precision(match self.merge {
+                        MergeBehavior::Sync => Some(self.sync_precision),
+                        _ => None,
+                    })
                     .threads(self.threads)
                     .audio_locale_output_map(
                         zip(self.audio.clone(), self.output_audio_locales.clone()).collect(),
@@ -560,7 +558,7 @@ async fn get_format(
                 },
             },
         }),
-        MergeBehavior::Auto => {
+        MergeBehavior::Auto | MergeBehavior::Sync => {
             let mut d_formats: Vec<(Duration, DownloadFormat)> = vec![];
 
             for (single_format, video, audio, subtitles) in format_pairs {

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -104,7 +104,7 @@ pub struct Archive {
         help = "If the merge behavior is 'auto', only download multiple video tracks if their length difference is higher than the given milliseconds"
     )]
     #[arg(long, default_value_t = 200)]
-    pub(crate) merge_auto_tolerance: u32,
+    pub(crate) merge_time_tolerance: u32,
     #[arg(help = "Tries to sync the timing of all downloaded audios to match one video")]
     #[arg(
         long_help = "Tries to sync the timing of all downloaded audios to match one video. \
@@ -577,7 +577,7 @@ async fn get_format(
                             .sub(single_format.duration)
                             .abs()
                             .num_milliseconds()
-                            < archive.merge_auto_tolerance.into() =>
+                            < archive.merge_time_tolerance.into() =>
                     {
                         // If less than `audio_error` apart, use same audio.
                         closest_format

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -106,12 +106,12 @@ pub struct Archive {
     #[arg(long, default_value_t = 200)]
     pub(crate) merge_time_tolerance: u32,
     #[arg(
-        help = "If the merge behavior is 'sync', specify the difference by which two fingerprints are considered equal, higher values can help if the algorithm fails"
+        help = "If the merge behavior is 'sync', specify the difference by which two fingerprints are considered equal, higher values can help when the algorithm fails"
     )]
     #[arg(long, default_value_t = 6)]
     pub(crate) sync_tolerance: u32,
     #[arg(
-        help = "If the merge behavior is 'sync', specify the amount of offset determination runs from which the final offset is calculated, higher values will take a lot more time but will result in more precise offsets"
+        help = "If the merge behavior is 'sync', specify the amount of offset determination runs from which the final offset is calculated, higher values will increase the time required but lead to more precise offsets"
     )]
     #[arg(long, default_value_t = 4)]
     pub(crate) sync_precision: u32,

--- a/crunchy-cli-core/src/archive/command.rs
+++ b/crunchy-cli-core/src/archive/command.rs
@@ -106,12 +106,12 @@ pub struct Archive {
     #[arg(long, default_value_t = 200)]
     pub(crate) merge_time_tolerance: u32,
     #[arg(
-        help = "If the merge behavior is 'sync', specify the difference by which two fingerprints are considered equal"
+        help = "If the merge behavior is 'sync', specify the difference by which two fingerprints are considered equal, higher values can help if the algorithm fails"
     )]
     #[arg(long, default_value_t = 6)]
     pub(crate) sync_tolerance: u32,
     #[arg(
-        help = "If the merge behavior is 'sync', specify the amount of offset determination runs from which the final offset is calculated"
+        help = "If the merge behavior is 'sync', specify the amount of offset determination runs from which the final offset is calculated, higher values will take a lot more time but will result in more precise offsets"
     )]
     #[arg(long, default_value_t = 4)]
     pub(crate) sync_precision: u32,

--- a/crunchy-cli-core/src/archive/filter.rs
+++ b/crunchy-cli-core/src/archive/filter.rs
@@ -333,7 +333,7 @@ impl Filter for ArchiveFilter {
                     .unwrap()
                     .push(episode.season_number)
             }
-            
+
             if episodes.is_empty() {
                 return Ok(None);
             }

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -304,7 +304,7 @@ impl Downloader {
                     .enumerate()
                     .map(|(i, f)| {
                         len_from_segments(&f.video.0.segments())
-                            - tmp_offsets.get(&i).map(|o| *o).unwrap_or_default()
+                            - tmp_offsets.get(&i).copied().unwrap_or_default()
                     })
                     .collect();
                 let min = formats_with_offset.iter().min().unwrap();
@@ -323,7 +323,7 @@ impl Downloader {
                 let mut audio_count: usize = 0;
                 let mut subtitle_count: usize = 0;
                 for (i, format) in self.formats.iter().enumerate() {
-                    let offset = offsets.get(&i).map(|o| *o).unwrap_or_default();
+                    let offset = offsets.get(&i).copied().unwrap_or_default();
                     let format_len = format
                         .video
                         .0
@@ -372,7 +372,7 @@ impl Downloader {
                 root_format.subtitles.extend(subtitle_append);
 
                 self.formats = vec![root_format];
-                video_offset = offsets.get(&root_format_idx).map(|o| *o);
+                video_offset = offsets.get(&root_format_idx).copied();
                 for raw_audio in raw_audios.iter_mut() {
                     raw_audio.video_idx = root_format_idx;
                 }
@@ -391,7 +391,7 @@ impl Downloader {
             audios.push(FFmpegAudioMeta {
                 path: raw_audio.path,
                 locale: raw_audio.locale,
-                start_time: audio_offsets.get(&raw_audio.format_id).map(|o| *o),
+                start_time: audio_offsets.get(&raw_audio.format_id).copied(),
                 video_idx: raw_audio.video_idx,
             })
         }

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -1,5 +1,6 @@
 use crate::utils::ffmpeg::FFmpegPreset;
 use crate::utils::filter::real_dedup_vec;
+use crate::utils::fmt::format_time_delta;
 use crate::utils::log::progress;
 use crate::utils::os::{
     cache_dir, is_special_file, temp_directory, temp_named_pipe, tempdir, tempfile,
@@ -595,7 +596,7 @@ impl Downloader {
 
         for (i, meta) in videos.iter().enumerate() {
             if let Some(start_time) = meta.start_time {
-                input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                input.extend(["-ss".to_string(), format_time_delta(&start_time)])
             }
             input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
             maps.extend(["-map".to_string(), i.to_string()]);
@@ -616,7 +617,7 @@ impl Downloader {
         }
         for (i, meta) in audios.iter().enumerate() {
             if let Some(start_time) = meta.start_time {
-                input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                input.extend(["-ss".to_string(), format_time_delta(&start_time)])
             }
             input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
             maps.extend(["-map".to_string(), (i + videos.len()).to_string()]);
@@ -663,7 +664,7 @@ impl Downloader {
         if container_supports_softsubs {
             for (i, meta) in subtitles.iter().enumerate() {
                 if let Some(start_time) = meta.start_time {
-                    input.extend(["-ss".to_string(), format_time_delta(start_time)])
+                    input.extend(["-ss".to_string(), format_time_delta(&start_time)])
                 }
                 input.extend(["-i".to_string(), meta.path.to_string_lossy().to_string()]);
                 maps.extend([
@@ -1390,8 +1391,8 @@ fn fix_subtitles(raw: &mut Vec<u8>, max_length: TimeDelta) {
                         format!(
                             "Dialogue: {},{},{},",
                             layer,
-                            format_time_delta(start),
-                            format_time_delta(end)
+                            format_time_delta(&start),
+                            format_time_delta(&end)
                         ),
                     )
                     .to_string()
@@ -1663,18 +1664,6 @@ fn check_frame_windows(base_hashes: &[ImageHash], check_hashes: &[ImageHash]) ->
         results.push(sum as f64 / check_window.len() as f64);
     }
     results
-}
-
-fn format_time_delta(time_delta: TimeDelta) -> String {
-    let hours = time_delta.num_hours();
-    let minutes = time_delta.num_minutes() - time_delta.num_hours() * 60;
-    let seconds = time_delta.num_seconds() - time_delta.num_minutes() * 60;
-    let milliseconds = time_delta.num_milliseconds() - time_delta.num_seconds() * 1000;
-
-    format!(
-        "{}:{:0>2}:{:0>2}.{:0>3}",
-        hours, minutes, seconds, milliseconds
-    )
 }
 
 fn len_from_segments(segments: &[StreamSegment]) -> TimeDelta {

--- a/crunchy-cli-core/src/utils/download.rs
+++ b/crunchy-cli-core/src/utils/download.rs
@@ -281,6 +281,7 @@ impl Downloader {
                     format_id: i,
                     path,
                     locale: locale.clone(),
+                    sample_rate: stream_data.sampling_rate().unwrap(),
                     video_idx: i,
                 })
             }

--- a/crunchy-cli-core/src/utils/fmt.rs
+++ b/crunchy-cli-core/src/utils/fmt.rs
@@ -1,0 +1,19 @@
+use chrono::TimeDelta;
+
+pub fn format_time_delta(time_delta: &TimeDelta) -> String {
+    let negative: bool = time_delta.abs() > *time_delta;
+    let time_delta = time_delta.abs();
+    let hours = time_delta.num_hours();
+    let minutes = time_delta.num_minutes() - time_delta.num_hours() * 60;
+    let seconds = time_delta.num_seconds() - time_delta.num_minutes() * 60;
+    let milliseconds = time_delta.num_milliseconds() - time_delta.num_seconds() * 1000;
+
+    format!(
+        "{}{}:{:0>2}:{:0>2}.{:0>3}",
+        if negative { "-" } else { "" },
+        hours,
+        minutes,
+        seconds,
+        milliseconds
+    )
+}

--- a/crunchy-cli-core/src/utils/fmt.rs
+++ b/crunchy-cli-core/src/utils/fmt.rs
@@ -1,7 +1,7 @@
 use chrono::TimeDelta;
 
 pub fn format_time_delta(time_delta: &TimeDelta) -> String {
-    let negative: bool = time_delta.abs() > *time_delta;
+    let negative = *time_delta < TimeDelta::zero();
     let time_delta = time_delta.abs();
     let hours = time_delta.num_hours();
     let minutes = time_delta.num_minutes() - time_delta.num_hours() * 60;

--- a/crunchy-cli-core/src/utils/format.rs
+++ b/crunchy-cli-core/src/utils/format.rs
@@ -544,7 +544,7 @@ impl Format {
                 path.set_file_name(format!("{}.{}", &name[..(255 - ext.len() - 1)], ext))
             }
         }
-        path.into_iter()
+        path.iter()
             .map(|s| {
                 if s.len() > 255 {
                     s.to_string_lossy()[..255].to_string()

--- a/crunchy-cli-core/src/utils/mod.rs
+++ b/crunchy-cli-core/src/utils/mod.rs
@@ -11,4 +11,5 @@ pub mod log;
 pub mod os;
 pub mod parse;
 pub mod rate_limit;
+pub mod sync;
 pub mod video;

--- a/crunchy-cli-core/src/utils/mod.rs
+++ b/crunchy-cli-core/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod download;
 pub mod ffmpeg;
 pub mod filter;
+pub mod fmt;
 pub mod format;
 pub mod interactive_select;
 pub mod locale;

--- a/crunchy-cli-core/src/utils/os.rs
+++ b/crunchy-cli-core/src/utils/os.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::process::{Command, Stdio};
 use std::task::{Context, Poll};
 use std::{env, fs, io};
-use tempfile::{Builder, NamedTempFile, TempDir, TempPath};
+use tempfile::{Builder, NamedTempFile, TempPath};
 use tokio::io::{AsyncRead, ReadBuf};
 
 pub fn has_ffmpeg() -> bool {
@@ -44,22 +44,6 @@ pub fn tempfile<S: AsRef<str>>(suffix: S) -> io::Result<NamedTempFile> {
         tempfile.path().to_string_lossy()
     );
     Ok(tempfile)
-}
-
-/// Any tempdir should be created with this function. The prefix and directory of every directory
-/// created  with this function stays the same which is helpful to query all existing tempdirs and
-/// e.g. remove them in a case of ctrl-c. Having one function also good to prevent mistakes like
-/// setting the wrong prefix if done manually.
-pub fn tempdir<S: AsRef<str>>(suffix: S) -> io::Result<TempDir> {
-    let tempdir = Builder::default()
-        .prefix(".crunchy-cli_")
-        .suffix(suffix.as_ref())
-        .tempdir_in(temp_directory())?;
-    debug!(
-        "Created temporary directory: {}",
-        tempdir.path().to_string_lossy()
-    );
-    Ok(tempdir)
 }
 
 pub fn cache_dir<S: AsRef<str>>(name: S) -> io::Result<PathBuf> {

--- a/crunchy-cli-core/src/utils/sync.rs
+++ b/crunchy-cli-core/src/utils/sync.rs
@@ -216,9 +216,9 @@ fn generate_chromaprint(
 ) -> Result<Vec<u32>> {
     let mut ss_argument: &TimeDelta = &start.checked_sub(offset).unwrap();
     let mut offset_argument = &TimeDelta::zero();
-    if offset.abs() > *offset {
+    if *offset < TimeDelta::zero() {
         ss_argument = start;
-        offset_argument = &offset;
+        offset_argument = offset;
     };
 
     let mut command = Command::new("ffmpeg");

--- a/crunchy-cli-core/src/utils/sync.rs
+++ b/crunchy-cli-core/src/utils/sync.rs
@@ -261,14 +261,14 @@ fn generate_chromaprint(
     // the stdout is read in chunks because keeping all the raw audio data in memory would take up
     // a significant amount of space
     let mut stdout = handle.stdout.take().unwrap();
-    let mut buf: [u8; 32_000] = [0; 32_000];
+    let mut buf: [u8; 128_000] = [0; 128_000];
     while handle.try_wait()?.is_none() {
         loop {
             let read_bytes = stdout.read(&mut buf)?;
             if read_bytes == 0 {
                 break;
             }
-            let data: [i16; 16_000] = unsafe { mem::transmute(buf) };
+            let data: [i16; 64_000] = unsafe { mem::transmute(buf) };
             printer.consume(&data[0..(read_bytes / 2)])
         }
     }

--- a/crunchy-cli-core/src/utils/sync.rs
+++ b/crunchy-cli-core/src/utils/sync.rs
@@ -1,0 +1,422 @@
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+    ops::Not,
+    path::Path,
+    process::Command,
+};
+
+use chrono::TimeDelta;
+use crunchyroll_rs::Locale;
+use log::debug;
+use tempfile::TempPath;
+
+use anyhow::{bail, Result};
+
+use super::fmt::format_time_delta;
+
+pub struct SyncAudio {
+    pub format_id: usize,
+    pub path: TempPath,
+    pub locale: Locale,
+    pub video_idx: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TimeRange {
+    start: f64,
+    end: f64,
+}
+
+pub fn sync_audios(
+    available_audios: &Vec<SyncAudio>,
+    sync_tolerance: u32,
+    sync_precision: u32,
+) -> Result<Option<HashMap<usize, TimeDelta>>> {
+    let mut result: HashMap<usize, TimeDelta> = HashMap::new();
+
+    let mut sync_audios = vec![];
+    let mut chromaprints = HashMap::new();
+    let mut formats = HashSet::new();
+    for audio in available_audios {
+        if formats.contains(&audio.format_id) {
+            continue;
+        }
+        formats.insert(audio.format_id);
+        sync_audios.push((audio.format_id, &audio.path));
+        chromaprints.insert(
+            audio.format_id,
+            generate_chromaprint(
+                &audio.path,
+                &TimeDelta::zero(),
+                &TimeDelta::zero(),
+                &TimeDelta::zero(),
+            )?,
+        );
+    }
+    sync_audios.sort_by_key(|sync_audio| chromaprints.get(&sync_audio.0).unwrap().len());
+
+    let base_audio = sync_audios.remove(0);
+
+    let mut start = f64::MAX;
+    let mut end = f64::MIN;
+    let mut initial_offsets = HashMap::new();
+    for audio in &sync_audios {
+        debug!(
+            "Initial comparison of format {} to {}",
+            audio.0, &base_audio.0
+        );
+
+        let (lhs_ranges, rhs_ranges) = compare_chromaprints(
+            chromaprints.get(&base_audio.0).unwrap(),
+            chromaprints.get(&audio.0).unwrap(),
+            sync_tolerance,
+        );
+        if lhs_ranges.is_empty() || rhs_ranges.is_empty() {
+            bail!(
+                "Failed to sync videos, couldn't find matching audio parts between format {} and {}",
+                base_audio.0 + 1,
+                audio.0 + 1
+            );
+        }
+        let lhs_range = lhs_ranges[0];
+        let rhs_range = rhs_ranges[0];
+        start = start.min(lhs_range.start);
+        end = end.max(lhs_range.end);
+        start = start.min(rhs_range.start);
+        end = end.max(rhs_range.end);
+        let offset = TimeDelta::milliseconds(((rhs_range.start - lhs_range.start) * 1000.0) as i64);
+        initial_offsets.insert(audio.0, TimeDelta::zero().checked_sub(&offset).unwrap());
+        debug!(
+            "Found initial offset of {}ms ({} - {} {}s) ({} - {} {}s) for format {} to {}",
+            offset.num_milliseconds(),
+            lhs_range.start,
+            lhs_range.end,
+            lhs_range.end - lhs_range.start,
+            rhs_range.start,
+            rhs_range.end,
+            rhs_range.end - rhs_range.start,
+            audio.0,
+            base_audio.0
+        );
+    }
+
+    debug!(
+        "Found matching audio parts at {} - {}, narrowing search",
+        start, end
+    );
+
+    let start = TimeDelta::milliseconds((start * 1000.0) as i64 - 20000);
+    let end = TimeDelta::milliseconds((end * 1000.0) as i64 + 20000);
+
+    for sync_audio in &sync_audios {
+        let chromaprint = generate_chromaprint(
+            &sync_audio.1,
+            &start,
+            &end,
+            initial_offsets.get(&sync_audio.0).unwrap(),
+        )?;
+        chromaprints.insert(sync_audio.0, chromaprint);
+    }
+
+    let mut runs: HashMap<usize, i64> = HashMap::new();
+    let iterator_range_limits: i64 = 2 ^ sync_precision as i64;
+    for i in -iterator_range_limits..=iterator_range_limits {
+        let base_offset = TimeDelta::milliseconds(
+            ((0.128 / iterator_range_limits as f64 * i as f64) * 1000.0) as i64,
+        );
+        chromaprints.insert(
+            base_audio.0,
+            generate_chromaprint(base_audio.1, &start, &end, &base_offset)?,
+        );
+        for audio in &sync_audios {
+            let initial_offset = initial_offsets.get(&audio.0).map(|o| *o).unwrap();
+            let offset = find_offset(
+                (&base_audio.0, chromaprints.get(&base_audio.0).unwrap()),
+                &base_offset,
+                (&audio.0, chromaprints.get(&audio.0).unwrap()),
+                &initial_offset,
+                &start,
+                sync_tolerance,
+            );
+            if offset.is_none() {
+                continue;
+            }
+            let offset = offset.unwrap();
+
+            result.insert(
+                audio.0,
+                result
+                    .get(&audio.0)
+                    .map(|o| *o)
+                    .unwrap_or_default()
+                    .checked_add(&offset)
+                    .unwrap(),
+            );
+            runs.insert(
+                audio.0,
+                runs.get(&audio.0).map(|o| *o).unwrap_or_default() + 1,
+            );
+        }
+    }
+    let mut result: HashMap<usize, TimeDelta> = result
+        .iter()
+        .map(|(format_id, offset)| {
+            (
+                *format_id,
+                TimeDelta::milliseconds(
+                    offset.num_milliseconds() / runs.get(format_id).map(|o| *o).unwrap(),
+                ),
+            )
+        })
+        .collect();
+    result.insert(base_audio.0, TimeDelta::milliseconds(0));
+
+    Ok(Some(result))
+}
+
+fn find_offset(
+    lhs: (&usize, &Vec<u32>),
+    lhs_shift: &TimeDelta,
+    rhs: (&usize, &Vec<u32>),
+    rhs_shift: &TimeDelta,
+    start: &TimeDelta,
+    sync_tolerance: u32,
+) -> Option<TimeDelta> {
+    let (lhs_ranges, rhs_ranges) = compare_chromaprints(&lhs.1, &rhs.1, sync_tolerance);
+    if lhs_ranges.is_empty() || rhs_ranges.is_empty() {
+        return None;
+    }
+    let lhs_range = lhs_ranges[0];
+    let rhs_range = rhs_ranges[0];
+    let offset = rhs_range.end - lhs_range.end;
+    let offset = TimeDelta::milliseconds((offset * 1000.0) as i64)
+        .checked_add(&lhs_shift)?
+        .checked_sub(&rhs_shift)?;
+    debug!(
+        "Found offset of {}ms ({} - {} {}s) ({} - {} {}s) for format {} to {}",
+        offset.num_milliseconds(),
+        lhs_range.start + start.num_milliseconds() as f64 / 1000.0,
+        lhs_range.end + start.num_milliseconds() as f64 / 1000.0,
+        lhs_range.end - lhs_range.start,
+        rhs_range.start + start.num_milliseconds() as f64 / 1000.0,
+        rhs_range.end + start.num_milliseconds() as f64 / 1000.0,
+        rhs_range.end - rhs_range.start,
+        rhs.0,
+        lhs.0
+    );
+    return Some(offset);
+}
+
+fn generate_chromaprint(
+    input_file: &Path,
+    start: &TimeDelta,
+    end: &TimeDelta,
+    offset: &TimeDelta,
+) -> Result<Vec<u32>> {
+    let mut ss_argument: &TimeDelta = &start.checked_sub(offset).unwrap();
+    let mut offset_argument = &TimeDelta::zero();
+    if offset.abs() > *offset {
+        ss_argument = start;
+        offset_argument = &offset;
+    };
+
+    let mut command = Command::new("ffmpeg");
+    command
+        .arg("-hide_banner")
+        .arg("-y")
+        .args(["-ss", format_time_delta(ss_argument).as_str()]);
+
+    if end.is_zero().not() {
+        command.args(["-to", format_time_delta(end).as_str()]);
+    }
+
+    command
+        .args(["-itsoffset", format_time_delta(offset_argument).as_str()])
+        .args(["-i", input_file.to_string_lossy().to_string().as_str()])
+        .args(["-ac", "2"])
+        .args(["-f", "chromaprint"])
+        .args(["-fp_format", "raw"])
+        .arg("-");
+
+    let extract_output = command.output()?;
+
+    if !extract_output.status.success() {
+        bail!(
+            "{}",
+            String::from_utf8_lossy(extract_output.stderr.as_slice())
+        );
+    }
+    let raw_chromaprint = extract_output.stdout.as_slice();
+    let length = raw_chromaprint.len();
+    if length % 4 != 0 {
+        bail!("chromaprint bytes should be a multiple of 4");
+    }
+    let mut chromaprint = Vec::with_capacity(length / 4);
+    for i in 0..length / 4 {
+        chromaprint.push(as_u32_le(
+            raw_chromaprint[i * 4 + 0..i * 4 + 4].try_into().unwrap(),
+        ));
+    }
+    return Ok(chromaprint);
+}
+
+fn compare_chromaprints(
+    lhs_chromaprint: &Vec<u32>,
+    rhs_chromaprint: &Vec<u32>,
+    sync_tolerance: u32,
+) -> (Vec<TimeRange>, Vec<TimeRange>) {
+    let lhs_inverse_index = create_inverse_index(&lhs_chromaprint);
+    let rhs_inverse_index = create_inverse_index(&rhs_chromaprint);
+
+    let mut possible_shifts = HashSet::new();
+    for lhs_pair in lhs_inverse_index {
+        let original_point = lhs_pair.0;
+        for i in -2..=2 {
+            let modified_point = (original_point as i32 + i) as u32;
+            if rhs_inverse_index.contains_key(&modified_point) {
+                let rhs_index = rhs_inverse_index.get(&modified_point).map(|o| *o).unwrap();
+                possible_shifts.insert(rhs_index as i32 - lhs_pair.1 as i32);
+            }
+        }
+    }
+
+    let mut all_lhs_time_ranges = vec![];
+    let mut all_rhs_time_ranges = vec![];
+    for shift_amount in possible_shifts {
+        let time_range_pair = find_time_ranges(
+            &lhs_chromaprint,
+            &rhs_chromaprint,
+            shift_amount,
+            sync_tolerance,
+        );
+        if time_range_pair.is_none() {
+            continue;
+        }
+        let (mut lhs_time_ranges, mut rhs_time_ranges) = time_range_pair.unwrap();
+        let mut lhs_time_ranges: Vec<TimeRange> = lhs_time_ranges
+            .drain(..)
+            .filter(|time_range| {
+                (20.0 < (time_range.end - time_range.start))
+                    && ((time_range.end - time_range.start) < 180.0)
+                    && time_range.end > 0.0
+            })
+            .collect();
+        lhs_time_ranges.sort_by(|a, b| (b.end - b.start).total_cmp(&(a.end - a.start)));
+        let mut rhs_time_ranges: Vec<TimeRange> = rhs_time_ranges
+            .drain(..)
+            .filter(|time_range| {
+                (20.0 < (time_range.end - time_range.start))
+                    && ((time_range.end - time_range.start) < 180.0)
+                    && time_range.end > 0.0
+            })
+            .collect();
+        rhs_time_ranges.sort_by(|a, b| (b.end - b.start).total_cmp(&(a.end - a.start)));
+        if lhs_time_ranges.is_empty() || rhs_time_ranges.is_empty() {
+            continue;
+        }
+
+        all_lhs_time_ranges.push(lhs_time_ranges[0]);
+        all_rhs_time_ranges.push(rhs_time_ranges[0]);
+    }
+    all_lhs_time_ranges.sort_by(|a, b| (a.end - a.start).total_cmp(&(b.end - b.start)));
+    all_lhs_time_ranges.reverse();
+    all_rhs_time_ranges.sort_by(|a, b| (a.end - a.start).total_cmp(&(b.end - b.start)));
+    all_rhs_time_ranges.reverse();
+
+    return (all_lhs_time_ranges, all_rhs_time_ranges);
+}
+
+fn create_inverse_index(chromaprint: &Vec<u32>) -> HashMap<u32, usize> {
+    let mut inverse_index = HashMap::with_capacity(chromaprint.capacity());
+    for i in 0..chromaprint.capacity() {
+        inverse_index.insert(chromaprint[i], i);
+    }
+    return inverse_index;
+}
+
+fn find_time_ranges(
+    lhs_chromaprint: &Vec<u32>,
+    rhs_chromaprint: &Vec<u32>,
+    shift_amount: i32,
+    sync_tolerance: u32,
+) -> Option<(Vec<TimeRange>, Vec<TimeRange>)> {
+    let mut lhs_shift: i32 = 0;
+    let mut rhs_shift: i32 = 0;
+    if shift_amount < 0 {
+        lhs_shift -= shift_amount;
+    } else {
+        rhs_shift += shift_amount;
+    }
+
+    let mut lhs_matching_timestamps = vec![];
+    let mut rhs_matching_timestamps = vec![];
+    let upper_limit =
+        cmp::min(lhs_chromaprint.len(), rhs_chromaprint.len()) as i32 - shift_amount.abs();
+
+    for i in 0..upper_limit {
+        let lhs_position = i + lhs_shift;
+        let rhs_position = i + rhs_shift;
+        let difference = (lhs_chromaprint[lhs_position as usize]
+            ^ rhs_chromaprint[rhs_position as usize])
+            .count_ones();
+
+        if difference > sync_tolerance {
+            continue;
+        }
+
+        lhs_matching_timestamps.push(lhs_position as f64 * 0.128);
+        rhs_matching_timestamps.push(rhs_position as f64 * 0.128);
+    }
+    lhs_matching_timestamps.push(f64::MAX);
+    rhs_matching_timestamps.push(f64::MAX);
+
+    let lhs_time_ranges = timestamps_to_ranges(lhs_matching_timestamps);
+    if lhs_time_ranges.is_none() {
+        return None;
+    }
+    let lhs_time_ranges = lhs_time_ranges.unwrap();
+    let rhs_time_ranges = timestamps_to_ranges(rhs_matching_timestamps).unwrap();
+
+    return Some((lhs_time_ranges, rhs_time_ranges));
+}
+
+fn timestamps_to_ranges(mut timestamps: Vec<f64>) -> Option<Vec<TimeRange>> {
+    if timestamps.is_empty() {
+        return None;
+    }
+
+    timestamps.sort_by(|a, b| a.total_cmp(b));
+
+    let mut time_ranges = vec![];
+    let mut current_range = TimeRange {
+        start: timestamps[0],
+        end: timestamps[0],
+    };
+
+    for i in 0..timestamps.len() - 1 {
+        let current = timestamps[i];
+        let next = timestamps[i + 1];
+        if next - current <= 1.0 {
+            current_range.end = next;
+            continue;
+        }
+
+        time_ranges.push(current_range.clone());
+        current_range.start = next;
+        current_range.end = next;
+    }
+    return if time_ranges.len() > 0 {
+        Some(time_ranges)
+    } else {
+        None
+    };
+}
+
+fn as_u32_le(array: &[u8; 4]) -> u32 {
+    #![allow(arithmetic_overflow)]
+    ((array[0] as u32) << 0)
+        | ((array[1] as u32) << 8)
+        | ((array[2] as u32) << 16)
+        | ((array[3] as u32) << 24)
+}


### PR DESCRIPTION
- moves `--sync-start` to `--merge sync`
- replaces video based syncing with audio based syncing
- adds `--sync-tolerance` and `--sync-precision` to control audio based fingerprinting
- fixes bug where a message would always be printed out that syncing failed regardless of the actual outcome (except when it failed for a different reason)
- remove now unused `fn tempdir` in `os.rs`
- updates readme and help messages to reflect the changes

Requires #392 [Merged]